### PR TITLE
fix thread-safety issue in go_runtime_cleanup

### DIFF
--- a/src/gcc_libinit.c
+++ b/src/gcc_libinit.c
@@ -108,10 +108,9 @@ int _cgo_try_pthread_create(
 
     for (tries = 0; tries < 20; tries++)
     {
-        err = pthread_create(thread, attr, pfn, arg);
+        err = go_rc_pthread_create(thread, attr, pfn, arg);
         if (err == 0)
         {
-            go_rc_add_thread(*thread);
             // pthread_detach(*thread);
             return 0;
         }

--- a/src/gcc_mmap.c
+++ b/src/gcc_mmap.c
@@ -24,14 +24,13 @@ uintptr_t x_cgo_mmap(
     void* p;
 
     _cgo_tsan_acquire();
-    p = mmap(addr, length, prot, flags, fd, offset);
+    p = go_rc_mmap(addr, length, prot, flags, fd, offset);
     _cgo_tsan_release();
     if (p == MAP_FAILED)
     {
         /* This is what the Go code expects on failure.  */
         return (uintptr_t)errno;
     }
-    go_rc_add_memory(p, length);
     return (uintptr_t)p;
 }
 
@@ -40,12 +39,11 @@ void x_cgo_munmap(void* addr, uintptr_t length)
     int r;
 
     _cgo_tsan_acquire();
-    r = munmap(addr, length);
+    r = go_rc_munmap(addr, length);
     _cgo_tsan_release();
     if (r < 0)
     {
         /* The Go runtime is not prepared for munmap to fail.  */
         abort();
     }
-    go_rc_remove_memory(addr, length);
 }

--- a/src/go_runtime_cleanup.h
+++ b/src/go_runtime_cleanup.h
@@ -8,33 +8,37 @@
 
 #include <openenclave/bits/defs.h>
 #include <pthread.h>
-#include <stddef.h>
-#include <stdint.h>
+#include <sys/mman.h>
 
 OE_EXTERNC_BEGIN
 
 /**
- * Adds a thread from the cleanup list.
- *
- * @param thread pthread.
+ * Creates a thread and adds it to the cleanup list.
  */
-void go_rc_add_thread(pthread_t thread);
+int go_rc_pthread_create(
+    pthread_t* thread,
+    const pthread_attr_t* attr,
+    void* (*start_routine)(void*),
+    void* arg);
 
 /**
- * Adds a mapped memory range to the cleanup list.
+ * Maps a memory range and adds it to the cleanup list.
+ */
+void* go_rc_mmap(
+    void* addr,
+    size_t length,
+    int prot,
+    int flags,
+    int fd,
+    off_t offset);
+
+/**
+ * Unmaps a mapped memory range and removes it from the cleanup list.
  *
  * @param addr Start address of the memory mapping.
  * @param length Length of the memory mapping in bytes.
  */
-void go_rc_add_memory(void* addr, uintptr_t length);
-
-/**
- * Removes a mapped memory range from the cleanup list.
- *
- * @param addr Start address of the memory mapping.
- * @param length Length of the memory mapping in bytes.
- */
-void go_rc_remove_memory(void* addr, uintptr_t length);
+int go_rc_munmap(void* addr, size_t length);
 
 /**
  * Cancels all threads in the cleanup list.


### PR DESCRIPTION
CI hangs sometimes in `ego run helloworld`. Couldn't reproduce, but added some debug code that showed that one thread is in go_rc_add_memory while main thread is in go_rc_kill_threads.

When go_rc_kill_threads is called, threads might just be in mmap or
pthread_create. Thus, kill_threads must be locked and creating a thread
and adding it to the cleanup list must be an atomic operation. Same
goes for mmap.