### PR TITLE
AB#628: Configurable mount points

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -2,68 +2,66 @@ name: Unit Tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
-
   build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/edgelesssys/edgelessrt-dev:ci
+      image: ghcr.io/edgelesssys/edgelessrt-dev:nightly
     steps:
+      - name: Check out code
+        uses: actions/checkout@v2
 
-    - name: Check out code
-      uses: actions/checkout@v2
+      - name: Setup
+        run: mkdir build
 
-    - name: Setup
-      run: mkdir build
+      - name: Build
+        run: |
+          cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DTIDY=ON ..
+          make -j`nproc`
+        working-directory: build
 
-    - name: Build
-      run: |
-        cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DTIDY=ON ..
-        make -j`nproc`
-      working-directory: build
+      - name: Test
+        run: OE_SIMULATION=1 ctest --output-on-failure
+        working-directory: build
 
-    - name: Test
-      run: OE_SIMULATION=1 ctest --output-on-failure
-      working-directory: build
+      - name: CPack
+        run: cpack -G DEB
+        working-directory: build
 
-    - name: CPack
-      run: cpack -G DEB
-      working-directory: build
+      - name: Build artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ego
+          path: build/*.deb
 
-    - name: Build artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: ego
-        path: build/*.deb
-
-    - name: Deploy ego-dev:nightly
-      if: github.ref == 'refs/heads/master' &&
+      - name: Deploy ego-dev:nightly
+        if: github.ref == 'refs/heads/master' &&
           github.event_name == 'push'
-      run: |
-        curl -X POST -H "Accept: application/vnd.github.v3+json" \
-        -H "Authorization: token ${{ secrets.CI_GITHUB_REPOSITORY }}" \
-        -d '{"event_type": "docker-build",
-            "client_payload":{"repository":"ego",
-                              "sign":"nightly",
-                              "imagename":"ego-dev",
-                              "tag":"nightly",
-                              "target":"ego-dev"}}' \
-        https://api.github.com/repos/edgelesssys/deployment/dispatches
+        run: |
+          curl -X POST -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization: token ${{ secrets.CI_GITHUB_REPOSITORY }}" \
+          -d '{"event_type": "docker-build",
+              "client_payload":{"repository":"ego",
+                                "sign":"nightly",
+                                "imagename":"ego-dev",
+                                "tag":"nightly",
+                                "target":"ego-dev"}}' \
+          https://api.github.com/repos/edgelesssys/deployment/dispatches
 
-    - name: Deploy ego-deploy:nightly
-      if: github.ref == 'refs/heads/master' &&
+      - name: Deploy ego-deploy:nightly
+        if: github.ref == 'refs/heads/master' &&
           github.event_name == 'push'
-      run: |
-        curl -X POST -H "Accept: application/vnd.github.v3+json" \
-        -H "Authorization: token ${{ secrets.CI_GITHUB_REPOSITORY }}" \
-        -d '{"event_type": "docker-build",
-            "client_payload":{"repository":"ego",
-                              "sign":"nightly",
-                              "imagename":"ego-deploy",
-                              "tag":"nightly",
-                              "target":"ego-deploy"}}' \
-        https://api.github.com/repos/edgelesssys/deployment/dispatches
+        run: |
+          curl -X POST -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization: token ${{ secrets.CI_GITHUB_REPOSITORY }}" \
+          -d '{"event_type": "docker-build",
+              "client_payload":{"repository":"ego",
+                                "sign":"nightly",
+                                "imagename":"ego-deploy",
+                                "tag":"nightly",
+                                "target":"ego-deploy"}}' \
+          https://api.github.com/repos/edgelesssys/deployment/dispatches

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ target_link_libraries(ego-enclave
 
 add_custom_command(
   OUTPUT ego
-  DEPENDS cmd/ego/main.go ${CMAKE_SOURCE_DIR}/internal/cli/*.go
+  DEPENDS cmd/ego/main.go ${CMAKE_SOURCE_DIR}/internal/cli/*.go ${CMAKE_SOURCE_DIR}/internal/config/*.go
   COMMAND go build -o ${CMAKE_CURRENT_BINARY_DIR}/ego
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/cmd/ego)
 add_custom_target(egobuild ALL DEPENDS ego)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,13 @@ add_library(ego-enclave-lib
   src/go_runtime_cleanup.cpp)
 target_link_libraries(ego-enclave-lib PRIVATE openenclave::oe_includes)
 
+add_custom_command(
+  OUTPUT premain.a
+  DEPENDS internal/premain/main.go internal/premain/core/core.go
+  COMMAND ertgo build -buildmode=c-archive -o ${CMAKE_BINARY_DIR}
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/internal/premain)
+add_custom_target(premainbuild DEPENDS premain.a)
+
 # Both ego-enclave and the payload use the local-exec TLS model. This means that TLS memory
 # will overlap. Quick fix is to reserve space in ego-enclave that we won't touch.
 # The Go language does not have TLS and the implementation only stores one pointer in TLS.
@@ -41,6 +48,7 @@ add_library(reserved_tls_last INTERFACE)
 target_link_libraries(reserved_tls_last INTERFACE reserved_tls)
 
 add_executable(ego-enclave src/gcc_libinit.c src/gcc_mmap.c)
+add_dependencies(ego-enclave premainbuild)
 target_link_libraries(ego-enclave
   openenclave::oeenclave
   openenclave::ertcalls
@@ -49,7 +57,7 @@ target_link_libraries(ego-enclave
   openenclave::oehostfs
   openenclave::oehostresolver
   openenclave::oehostsock
-  openenclave::ertmeshpremain
+  ${CMAKE_BINARY_DIR}/premain.a
   openenclave::ertlibc
   -Wl,--whole-archive
   openenclave::oelibc

--- a/cmd/integration-test/enclave.json
+++ b/cmd/integration-test/enclave.json
@@ -1,0 +1,20 @@
+{
+    "exe": "integration-test",
+    "key": "private.pem",
+    "debug": true,
+    "heapSize": 512,
+    "productID": 1,
+    "securityVersion": 1,
+    "mounts": [
+        {
+            "source": "/tmp/ego-integration-test",
+            "target": "/data",
+            "type": "hostfs",
+            "readOnly": false
+        },
+        {
+            "target": "/memfs",
+            "type": "memfs"
+        }
+    ]
+}

--- a/cmd/integration-test/main.go
+++ b/cmd/integration-test/main.go
@@ -1,0 +1,40 @@
+// Copyright (c) Edgeless Systems GmbH.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package main
+
+import (
+	"io/ioutil"
+	"log"
+
+	"github.com/edgelesssys/ego/internal/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func main() {
+	var t test.T
+	defer t.Exit()
+
+	assert := assert.New(&t)
+	require := require.New(&t)
+
+	log.Println("Welcome to the enclave.")
+	testFileSystemMounts(assert, require)
+}
+
+func testFileSystemMounts(assert *assert.Assertions, require *require.Assertions) {
+	log.Println("Testing hostfs mounts...")
+	fileContent, err := ioutil.ReadFile("/data/test-file.txt")
+	require.NoError(err)
+	assert.Equal("It works!", string(fileContent))
+
+	log.Println("Testing memfs mounts...")
+	err = ioutil.WriteFile("/memfs/test-file.txt", fileContent, 0)
+	require.NoError(err)
+	newFileContent, err := ioutil.ReadFile("/memfs/test-file.txt")
+	assert.Equal("It works!", string(newFileContent))
+}

--- a/doc/ego_cli.md
+++ b/doc/ego_cli.md
@@ -102,12 +102,24 @@ An enclave configuration is defined in JSON and applied when signing an executab
 Here is an example configuration:
 ```json
 {
- "exe": "helloworld",
- "key": "private.pem",
- "debug": true,
- "heapSize": 512,
- "productID": 1,
- "securityVersion": 1
+    "exe": "helloworld",
+    "key": "private.pem",
+    "debug": true,
+    "heapSize": 512,
+    "productID": 1,
+    "securityVersion": 1,
+    "mounts": [
+        {
+            "source": "/home/user",
+            "target": "/data",
+            "type": "hostfs",
+            "readOnly": false
+        },
+        {
+            "target": "/tmp",
+            "type": "memfs"
+        }
+    ]
 }
 ```
 
@@ -125,3 +137,10 @@ If `debug` is true, the enclave will be debuggable.
 A `productID` (SGX: ISVPRODID) is assigned by the developer and enables the attester to distinguish between different enclaves signed with the same key.
 
 The developer should increment the `securityVersion` (SGX: ISVSVN) whenever a security fix is made to the enclave code.
+
+`mounts` defines custom mount points which apply to the file system presented to the enclave. This can be `null` if no mounts other than the default mounts should be performed, or you can define multiple entries with the following parameters:
+
+  * `source` (required for `hostfs`): The directory from host file system which should be mounted in the enclave when using `hostfs`. For `memfs`, this value will be ignored and can be omitted.
+  * `target` (required): Defines the mount path in the enclave.
+  * `type` (required): Either `hostfs` if you want to mount a path from the host's file system in the enclave, or `memfs` if you want to use a temporary file system similar to *tmpfs* on UNIX systems.
+  * `readOnly`: Can be `true` or `false` depending on if you want to mount the path as read-only or read-write. When omitted, will default to read-write.

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
@@ -49,6 +50,7 @@ github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:Htrtb
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
+github.com/edgelesssys/ertgolib v0.1.3 h1:rsovbVQNs6oqNXSdRUaTZkgn6yhi7zbAHBsTNlcQpVM=
 github.com/edgelesssys/ertgolib v0.1.3/go.mod h1:1E8jAgXZp9wyP3n43wCsLCiEGXxjBQ35+uzxUkypBNs=
 github.com/edgelesssys/marblerun v0.2.0 h1:luFTwT4eJRXTRRTudZnQEgO7iudA4x23dfWi8DxKRgM=
 github.com/edgelesssys/marblerun v0.2.0/go.mod h1:SfPX0ip+xQJu6MzZUhtiEgVGCsc3GCAKa7A90av3n4U=
@@ -109,6 +111,7 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
@@ -309,6 +312,7 @@ golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897 h1:pLI5jrR7OSLijeIDcmRxNmw2api+jEfxLoykJVice/E=
 golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -394,6 +398,7 @@ golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgw
 golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200103221440-774c71fcf114/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200207183749-b753a1ba74fa h1:5E4dL8+NgFOgjwbTKz+OOEGGhP+ectTmF842l6KjupQ=
 golang.org/x/tools v0.0.0-20200207183749-b753a1ba74fa/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -459,6 +464,7 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
+honnef.co/go/tools v0.0.1-2019.2.3 h1:3JgtbtFHMiCmsznwGVTUWbgGov+pVqnlf1dEJTNAXeM=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0/go.mod h1:hI742Nqp5OhwiqlzhgfbWU4mW4yO10fP+LoT9WOswdU=

--- a/internal/cli/sign_test.go
+++ b/internal/cli/sign_test.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/edgelesssys/ego/internal/config"
 	"github.com/google/go-cmp/cmp"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -227,7 +228,7 @@ func TestSignJSONExecutablePayload(t *testing.T) {
 	unsignedExeMemfs.Close()
 
 	// Create a default config we want to check
-	testConf := &config{
+	testConf := &config.Config{
 		Exe:             exe,
 		Key:             defaultPrivKeyFilename,
 		Debug:           true,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,10 +45,25 @@ func (c *Config) Validate() error {
 	// Validate file system mounts
 	alreadyUsedMountPoints := make(map[string]bool, len(c.Mounts))
 	for _, mountPoint := range c.Mounts {
+		// Check if target is defined
+		if mountPoint.Target == "" {
+			return fmt.Errorf("missing target for mount declaration")
+		}
+
 		// Check if a target is defined multiple times. This will cause the syscall in the premain to return an error.
 		if _, ok := alreadyUsedMountPoints[mountPoint.Target]; ok {
 			fmt.Printf("ERROR: '%s': Mount point was defined multiple times. Check your configuration.", mountPoint.Target)
 			return fmt.Errorf("mount target '%s' was defined multiple times", mountPoint.Target)
+		}
+
+		// Check if type is defined
+		if mountPoint.Type == "" {
+			return fmt.Errorf("missing type for mount target '%s'", mountPoint.Target)
+		}
+
+		// Check if source is not empty when using hostfs
+		if mountPoint.Type == "hostfs" && mountPoint.Source == "" {
+			return fmt.Errorf("no source given for mount target '%s", mountPoint.Target)
 		}
 
 		// Check if 'hostfs' or 'memfs' was set as type

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,45 @@
+// Copyright (c) Edgeless Systems GmbH.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package config
+
+import (
+	"fmt"
+)
+
+// Config defines the structure of enclave.json, containing the settings for the enclave runtime
+type Config struct {
+	Exe             string            `json:"exe"`
+	Key             string            `json:"key"`
+	Debug           bool              `json:"debug"`
+	HeapSize        int               `json:"heapSize"`
+	ProductID       int               `json:"productID"`
+	SecurityVersion int               `json:"securityVersion"`
+	Mounts          []FileSystemMount `json:"mounts"`
+}
+
+// FileSystemMount defines a single mount point for the enclave's filesystem
+// either from the enclave's host system (hostfs), or a virtual file system running in the enclave's memory (memfs).
+type FileSystemMount struct {
+	Source   string `json:"source"`
+	Target   string `json:"target"`
+	Type     string `json:"type"`
+	ReadOnly bool   `json:"readOnly"`
+}
+
+// Validate Exe, Key, HeapSize
+func (c *Config) Validate() error {
+	if c.HeapSize == 0 {
+		return fmt.Errorf("heapSize not set in config file")
+	}
+	if c.Exe == "" {
+		return fmt.Errorf("exe not set in config file")
+	}
+	if c.Key == "" {
+		return fmt.Errorf("key not set in config file")
+	}
+	return nil
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,66 @@
+// Copyright (c) Edgeless Systems GmbH.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidate(t *testing.T) {
+	assert := assert.New(t)
+
+	config := Config{}
+
+	// Empty config, should fail
+	assert.Error(config.Validate())
+
+	// Set heapSize, should still fail
+	config.HeapSize = 512
+	assert.Error(config.Validate())
+
+	// Set exe, should still fail
+	config.Exe = "text_exe"
+	assert.Error(config.Validate())
+
+	// Set key, should pass now
+	config.Key = "somekey.key"
+	assert.NoError(config.Validate())
+
+	// Set two valid mount options, should pass
+	config.Mounts = make([]FileSystemMount, 2)
+
+	// Run with empty mounts, should fail
+	assert.Error(config.Validate())
+
+	// Run with empty type, should fail
+	config.Mounts[0] = FileSystemMount{Source: "/", Target: "/data_memfs", ReadOnly: false}
+	assert.Error(config.Validate())
+
+	// Run with proper definitions for mounts, should pass
+	config.Mounts[0] = FileSystemMount{Source: "/", Target: "/data_memfs", Type: "memfs", ReadOnly: false}
+	config.Mounts[1] = FileSystemMount{Source: "/home/benjaminfranklin", Target: "/data", Type: "hostfs", ReadOnly: false}
+	assert.NoError(config.Validate())
+
+	// Specify source path for memfs & set it as read only. Really makes no sense and throws warnings, but should pass.
+	config.Mounts[0] = FileSystemMount{Source: "/blabla", Target: "/data_memfs", Type: "memfs", ReadOnly: true}
+	assert.NoError(config.Validate())
+
+	// Specify no source hostfs, should fail
+	config.Mounts[0] = FileSystemMount{Source: "", Target: "/sometarget", Type: "hostfs", ReadOnly: true}
+	assert.Error(config.Validate())
+
+	// Specify two mounts with /data_memfs as target, should fail
+	config.Mounts[0] = FileSystemMount{Source: "/blabla", Target: "/data_memfs", Type: "memfs", ReadOnly: true}
+	config.Mounts[1] = FileSystemMount{Source: "/home/benjaminfranklin", Target: "/data_memfs", Type: "hostfs", ReadOnly: false}
+	assert.Error(config.Validate())
+
+	// Specify garbage fs, should fail
+	config.Mounts[0] = FileSystemMount{Source: "/makesNoSense", Target: "/bin", Type: "rubbishfs", ReadOnly: true}
+	assert.Error(config.Validate())
+}

--- a/internal/premain/core/core.go
+++ b/internal/premain/core/core.go
@@ -7,14 +7,49 @@
 package core
 
 import (
+	"encoding/json"
 	"os"
+	"syscall"
 
+	"github.com/edgelesssys/ego/internal/config"
 	"github.com/edgelesssys/marblerun/marble/premain"
 )
 
 // PreMain runs before the App's actual main routine and initializes the EGo enclave.
 func PreMain(payload string) error {
-	// TODO
+	if len(payload) > 0 {
+		// Load config from embedded payload
+		var config config.Config
+		if err := json.Unmarshal([]byte(payload), &config); err != nil {
+			return err
+		}
+
+		// Perform mounts
+		for _, mountPoint := range config.Mounts {
+			var err error
+
+			switch mountPoint.Type {
+			case "hostfs":
+				if mountPoint.ReadOnly {
+					err = syscall.Mount(mountPoint.Source, mountPoint.Target, "oe_host_file_system", syscall.MS_RDONLY, "")
+				} else {
+					err = syscall.Mount(mountPoint.Source, mountPoint.Target, "oe_host_file_system", 0, "")
+				}
+
+			case "memfs":
+				if mountPoint.ReadOnly {
+					err = syscall.Mount("/", mountPoint.Target, "edg_memfs", syscall.MS_RDONLY, "")
+				} else {
+					err = syscall.Mount("/", mountPoint.Target, "edg_memfs", 0, "")
+				}
+			}
+
+			if err != nil {
+				return err
+			}
+		}
+	}
+
 	// If program is running as a Marble, continue with Marblerun Premain.
 	if os.Getenv("EDG_EGO_PREMAIN") == "1" {
 		return premain.PreMain()

--- a/internal/premain/core/core.go
+++ b/internal/premain/core/core.go
@@ -8,6 +8,7 @@ package core
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"syscall"
 
@@ -15,8 +16,13 @@ import (
 	"github.com/edgelesssys/marblerun/marble/premain"
 )
 
+// Mounter defines an interface to use to mount the filesystem (usually syscall, mainly differs for unit tests)
+type Mounter interface {
+	Mount(source string, target string, filesystem string, flags uintptr, data string) error
+}
+
 // PreMain runs before the App's actual main routine and initializes the EGo enclave.
-func PreMain(payload string) error {
+func PreMain(payload string, mounter Mounter) error {
 	if len(payload) > 0 {
 		// Load config from embedded payload
 		var config config.Config
@@ -24,35 +30,43 @@ func PreMain(payload string) error {
 			return err
 		}
 
-		// Perform mounts
-		for _, mountPoint := range config.Mounts {
-			var err error
-
-			switch mountPoint.Type {
-			case "hostfs":
-				if mountPoint.ReadOnly {
-					err = syscall.Mount(mountPoint.Source, mountPoint.Target, "oe_host_file_system", syscall.MS_RDONLY, "")
-				} else {
-					err = syscall.Mount(mountPoint.Source, mountPoint.Target, "oe_host_file_system", 0, "")
-				}
-
-			case "memfs":
-				if mountPoint.ReadOnly {
-					err = syscall.Mount("/", mountPoint.Target, "edg_memfs", syscall.MS_RDONLY, "")
-				} else {
-					err = syscall.Mount("/", mountPoint.Target, "edg_memfs", 0, "")
-				}
-			}
-
-			if err != nil {
-				return err
-			}
+		// Perform mounts based on embedded config
+		if err := performMounts(config, mounter); err != nil {
+			return err
 		}
 	}
 
 	// If program is running as a Marble, continue with Marblerun Premain.
 	if os.Getenv("EDG_EGO_PREMAIN") == "1" {
 		return premain.PreMain()
+	}
+
+	return nil
+}
+
+func performMounts(config config.Config, mounter Mounter) error {
+	for _, mountPoint := range config.Mounts {
+		// Setup flags for read-only or read-write
+		var flags uintptr
+		if mountPoint.ReadOnly {
+			flags = syscall.MS_RDONLY
+		}
+
+		// Mount filesystem
+		var err error
+		switch mountPoint.Type {
+		case "hostfs":
+			err = mounter.Mount(mountPoint.Source, mountPoint.Target, "oe_host_file_system", flags, "")
+		case "memfs":
+			err = mounter.Mount("/", mountPoint.Target, "edg_memfs", flags, "")
+		// This should not happen, as 'ego sign' is supposed to validate the config before embedding & signing it
+		default:
+			return errors.New("encountered an unknown filesystem type in configuration")
+		}
+
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/internal/premain/core/core.go
+++ b/internal/premain/core/core.go
@@ -6,10 +6,19 @@
 
 package core
 
-import "github.com/edgelesssys/marblerun/marble/premain"
+import (
+	"os"
+
+	"github.com/edgelesssys/marblerun/marble/premain"
+)
 
 // PreMain runs before the App's actual main routine and initializes the EGo enclave.
-func PreMain() error {
+func PreMain(payload string) error {
 	// TODO
-	return premain.PreMain()
+	// If program is running as a Marble, continue with Marblerun Premain.
+	if os.Getenv("EDG_EGO_PREMAIN") == "1" {
+		return premain.PreMain()
+	}
+
+	return nil
 }

--- a/internal/premain/core/core.go
+++ b/internal/premain/core/core.go
@@ -1,0 +1,15 @@
+// Copyright (c) Edgeless Systems GmbH.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package core
+
+import "github.com/edgelesssys/marblerun/marble/premain"
+
+// PreMain runs before the App's actual main routine and initializes the EGo enclave.
+func PreMain() error {
+	// TODO
+	return premain.PreMain()
+}

--- a/internal/premain/core/core_test.go
+++ b/internal/premain/core/core_test.go
@@ -1,0 +1,126 @@
+// Copyright (c) Edgeless Systems GmbH.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package core
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"syscall"
+	"testing"
+
+	"github.com/edgelesssys/ego/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type assertionMounter struct {
+	assert      *assert.Assertions
+	config      *config.Config
+	usedTargets map[string]bool
+}
+
+func TestPremain(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	//sane default values
+	conf := &config.Config{
+		Exe:             "helloworld",
+		Key:             "privatekey",
+		Debug:           true,
+		HeapSize:        512, //[MB]
+		ProductID:       1,
+		SecurityVersion: 1,
+		Mounts:          []config.FileSystemMount{{Source: "/", Target: "/memfs", Type: "memfs", ReadOnly: false}, {Source: "/home/benjaminfranklin", Target: "/data", Type: "hostfs", ReadOnly: true}},
+	}
+
+	// Supply valid payload, no Marble
+	mounter := assertionMounter{assert: assert, config: conf, usedTargets: make(map[string]bool)}
+	assert.NoError(PreMain("", &mounter))
+
+	// Supply valid payload, no Marble
+	payload, err := json.Marshal(conf)
+	require.NoError(err)
+	mounter = assertionMounter{assert: assert, config: conf, usedTargets: make(map[string]bool)}
+	assert.NoError(PreMain(string(payload), &mounter))
+
+	// Supply invalid payload, should fail
+	payload = []byte("blablarubbish")
+	assert.Error(PreMain(string(payload), &mounter))
+}
+
+func TestPerformMounts(t *testing.T) {
+	assert := assert.New(t)
+
+	//sane default values
+	conf := &config.Config{
+		Exe:             "helloworld",
+		Key:             "privatekey",
+		Debug:           true,
+		HeapSize:        512, //[MB]
+		ProductID:       1,
+		SecurityVersion: 1,
+		Mounts:          []config.FileSystemMount{{Source: "/", Target: "/memfs", Type: "memfs", ReadOnly: false}, {Source: "/home/benjaminfranklin", Target: "/data", Type: "hostfs", ReadOnly: true}},
+	}
+
+	mounter := assertionMounter{assert: assert, config: conf, usedTargets: make(map[string]bool)}
+	assert.NoError(performMounts(*conf, &mounter))
+
+	conf.Mounts = []config.FileSystemMount{{Source: "/home/benjaminfranklin", Target: "/data", Type: "rubbishfs", ReadOnly: true}}
+	assert.Error(performMounts(*conf, &mounter))
+}
+
+func (a *assertionMounter) Mount(source string, target string, filesystem string, flags uintptr, data string) error {
+	// Find corresponding mount point in config by searching for the target
+	var currentMountPoint config.FileSystemMount
+
+	// Find target from config to check against
+	// Additionally, check if it's already been mounted
+	for _, mountPoint := range a.config.Mounts {
+		if target == mountPoint.Target {
+			if _, ok := a.usedTargets[mountPoint.Target]; ok {
+				return errors.New("target already exists")
+			}
+
+			currentMountPoint = mountPoint
+			break
+		}
+	}
+
+	// We should not end up here, use this when we did not find any entry in the config
+	if currentMountPoint.Type == "" {
+		return errors.New("could not find equal mount declaration in supplied config")
+	}
+
+	if filesystem == "oe_host_file_system" {
+		a.assert.EqualValues(currentMountPoint.Source, source)
+		a.assert.EqualValues(currentMountPoint.Target, target)
+		a.assert.EqualValues("hostfs", currentMountPoint.Type)
+	} else if filesystem == "edg_memfs" {
+		a.assert.EqualValues("/", source)
+		a.assert.EqualValues(currentMountPoint.Target, target)
+		a.assert.EqualValues("memfs", currentMountPoint.Type)
+	} else {
+		return errors.New("encountered a call to an unknown filesystem type")
+	}
+
+	if flags == syscall.MS_RDONLY {
+		a.assert.True(currentMountPoint.ReadOnly)
+	} else if flags == 0 {
+		a.assert.False(currentMountPoint.ReadOnly)
+	} else {
+		return fmt.Errorf("unexpected flag supplied to mount: %d", flags)
+	}
+
+	a.assert.Empty(data)
+
+	// Add to usedTargets list for duplication check
+	a.usedTargets[currentMountPoint.Target] = true
+
+	return nil
+}

--- a/internal/premain/main.go
+++ b/internal/premain/main.go
@@ -19,8 +19,8 @@ var cargs []*C.char
 func main() {}
 
 //export ert_ego_premain
-func ert_ego_premain(argc *C.int, argv ***C.char) {
-	if err := core.PreMain(); err != nil {
+func ert_ego_premain(argc *C.int, argv ***C.char, payload *C.char) {
+	if err := core.PreMain(C.GoString(payload)); err != nil {
 		panic(err)
 	}
 

--- a/internal/premain/main.go
+++ b/internal/premain/main.go
@@ -1,0 +1,34 @@
+// Copyright (c) Edgeless Systems GmbH.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package main
+
+import "C"
+
+import (
+	"os"
+
+	"github.com/edgelesssys/ego/internal/premain/core"
+)
+
+var cargs []*C.char
+
+func main() {}
+
+//export ert_ego_premain
+func ert_ego_premain(argc *C.int, argv ***C.char) {
+	if err := core.PreMain(); err != nil {
+		panic(err)
+	}
+
+	cargs = make([]*C.char, len(os.Args)+1)
+	for i, a := range os.Args {
+		cargs[i] = C.CString(a)
+	}
+
+	*argc = C.int(len(os.Args))
+	*argv = &cargs[0]
+}

--- a/src/enc.cpp
+++ b/src/enc.cpp
@@ -26,7 +26,7 @@ using namespace ert;
 static int _argc;
 static char** _argv;
 
-extern "C" void ert_meshentry_premain(int* argc, char*** argv);
+extern "C" void ert_ego_premain(int* argc, char*** argv);
 static char** _merge_argv_env(int argc, char** argv, char** envp);
 
 extern "C" __thread char ert_ego_reserved_tls[1024];
@@ -91,7 +91,7 @@ int emain()
     if (is_marblerun)
     {
         _log_verbose("invoking premain");
-        ert_meshentry_premain(&_argc, &_argv);
+        ert_ego_premain(&_argc, &_argv);
         _log_verbose("premain done");
         _argv = _merge_argv_env(_argc, _argv, environ);
     }

--- a/src/integration_test.sh
+++ b/src/integration_test.sh
@@ -9,6 +9,7 @@ onexit()
         echo "All tests passed!"
     fi
     rm -r $tPath
+    rm -r /tmp/ego-integration-test
 }
 
 trap onexit EXIT
@@ -30,8 +31,17 @@ cmake -DCMAKE_INSTALL_PREFIX=$tPath/install $egoPath
 make -j`nproc`
 make install
 export PATH="$tPath/install/bin:$PATH"
-cp $egoPath/samples/helloworld/helloworld.go .
 
-run ego-go build helloworld.go
-run ego sign helloworld
-run ego run helloworld
+# Setup integration test
+mkdir -p /tmp/ego-integration-test
+echo -n -e "It works!" > /tmp/ego-integration-test/test-file.txt
+
+# Build integration test
+cd $egoPath/cmd/integration-test/
+cp enclave.json /tmp/ego-integration-test/enclave.json
+run ego-go build -o /tmp/ego-integration-test/integration-test
+
+# Sign & run intergration test
+cd /tmp/ego-integration-test
+run ego sign
+run ego run integration-test


### PR DESCRIPTION
(requires a recent build of Edgeless RT with payload data support)

Changes made in this PR:
- premain (based on ref/meshpremain)
- Moves the definition for enclave.json from "sign.go" into an own module named "config"
- Adds 'mounts' as an option for enclave.json, defining additional mount points
- Loads the embedded config file (which gets embedded during 'ego sign' from the previous PR) from the executable
- Runs premain, performs the user-defined mounts, continues with the execution of the original application (or alternatively when running a Marble, jumps into the Marblerun premain)

I think it's important to check the general UX here if it's somewhat intuitive to use and if it no configurations with the mounts are possible. There are many cases an user can make up unreasonable settings, hope I covered most of them with my checks.

Example for a new enclave.json:
```json
{
    "exe": "helloworld",
    "key": "private.pem",
    "debug": true,
    "heapSize": 512,
    "productID": 1,
    "securityVersion": 1,
    "mounts": [
        {
            "source": "/home/benjaminfranklin",
            "target": "/data",
            "type": "hostfs",
            "readOnly": false
        },
        {
            "source": "/",
            "target": "/tmp",
            "type": "memfs",
            "readOnly": false
        }
    ]
}
```

Looking forward for feedback! :) 