### PR TITLE
AB#629: User-definable environment variables

### DIFF
--- a/cmd/integration-test/enclave.json
+++ b/cmd/integration-test/enclave.json
@@ -19,11 +19,11 @@
     ],
     "env": [
         {
-            "Name": "HELLO_WORLD",
-            "Value": "Let's hope this passes the test :)"
+            "name": "HELLO_WORLD",
+            "value": "Let's hope this passes the test :)"
         },
         {
-            "Name": "PWD",
+            "name": "PWD",
             "fromHost": true
         }
     ]

--- a/cmd/integration-test/enclave.json
+++ b/cmd/integration-test/enclave.json
@@ -16,5 +16,15 @@
             "target": "/memfs",
             "type": "memfs"
         }
+    ],
+    "env": [
+        {
+            "Name": "HELLO_WORLD",
+            "Value": "Let's hope this passes the test :)"
+        },
+        {
+            "Name": "PWD",
+            "fromHost": true
+        }
     ]
 }

--- a/cmd/integration-test/main.go
+++ b/cmd/integration-test/main.go
@@ -49,6 +49,9 @@ func testEnvVars(assert *assert.Assertions, require *require.Assertions) {
 	require.NoError(err)
 	assert.Equal(currentPwd, os.Getenv("PWD"))
 
-	// Test if no existing env vars were taken over
-	assert.Empty(os.Getenv("OE_IS_ENCLAVE"))
+	// Test if OE_IS_ENCLAVE is set
+	assert.Equal("1", os.Getenv("OE_IS_ENCLAVE"))
+
+	// Check if other env vars were not taken over by using a common one to check against (here: LANG)
+	assert.Empty(os.Getenv("LANG"))
 }

--- a/cmd/integration-test/main.go
+++ b/cmd/integration-test/main.go
@@ -9,6 +9,7 @@ package main
 import (
 	"io/ioutil"
 	"log"
+	"os"
 
 	"github.com/edgelesssys/ego/internal/test"
 	"github.com/stretchr/testify/assert"
@@ -24,6 +25,7 @@ func main() {
 
 	log.Println("Welcome to the enclave.")
 	testFileSystemMounts(assert, require)
+	testEnvVars(assert, require)
 }
 
 func testFileSystemMounts(assert *assert.Assertions, require *require.Assertions) {
@@ -37,4 +39,16 @@ func testFileSystemMounts(assert *assert.Assertions, require *require.Assertions
 	require.NoError(err)
 	newFileContent, err := ioutil.ReadFile("/memfs/test-file.txt")
 	assert.Equal("It works!", string(newFileContent))
+}
+
+func testEnvVars(assert *assert.Assertions, require *require.Assertions) {
+	// Test if new env vars were set
+	log.Println("Testing env vars...")
+	assert.Equal("Let's hope this passes the test :)", os.Getenv("HELLO_WORLD"))
+	currentPwd, err := os.Getwd()
+	require.NoError(err)
+	assert.Equal(currentPwd, os.Getenv("PWD"))
+
+	// Test if no existing env vars were taken over
+	assert.Empty(os.Getenv("OE_IS_ENCLAVE"))
 }

--- a/doc/ego_cli.md
+++ b/doc/ego_cli.md
@@ -119,6 +119,16 @@ Here is an example configuration:
             "target": "/tmp",
             "type": "memfs"
         }
+    ],
+    "env": [
+        {
+            "name": "LANG",
+            "value": "en_US.UTF-8"
+        },
+        {
+            "name": "PWD",
+            "fromHost": true
+        }
     ]
 }
 ```
@@ -144,3 +154,9 @@ The developer should increment the `securityVersion` (SGX: ISVSVN) whenever a se
   * `target` (required): Defines the mount path in the enclave.
   * `type` (required): Either `hostfs` if you want to mount a path from the host's file system in the enclave, or `memfs` if you want to use a temporary file system similar to *tmpfs* on UNIX systems.
   * `readOnly`: Can be `true` or `false` depending on if you want to mount the path as read-only or read-write. When omitted, will default to read-write.
+
+`env` holds environment variables to set or take over from the host inside the enclave. By default, all environment variables not starting with `EDG_` are dropped when entering the enclave (except for `OE_IS_ENCLAVE`, which can be used as an indicator that we are inside an enclave).
+
+  * `name` (required): The name of the environment variable (what you put before `=`)
+  * `value` (required if not `fromHost`): The value of the environment variable (what you put after `=`)
+  * `fromHost`: When set to `true`, the current value of the requested environment variable will be copied over if it exists on the host. If the host does not hold this variable, it will either fall back to the value set in `value` (if it exists), or will not be created at all.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -60,7 +60,7 @@ func (c *Config) Validate() error {
 
 		// Check if a target is defined multiple times. This will cause the syscall in the premain to return an error.
 		if _, ok := alreadyUsedMountPoints[mountPoint.Target]; ok {
-			fmt.Printf("ERROR: '%s': Mount point was defined multiple times. Check your configuration.", mountPoint.Target)
+			fmt.Printf("ERROR: '%s': Mount point was defined multiple times. Check your configuration.\n", mountPoint.Target)
 			return fmt.Errorf("mount target '%s' was defined multiple times", mountPoint.Target)
 		}
 
@@ -76,18 +76,18 @@ func (c *Config) Validate() error {
 
 		// Check if 'hostfs' or 'memfs' was set as type
 		if mountPoint.Type != "hostfs" && mountPoint.Type != "memfs" {
-			fmt.Printf("ERROR: '%s': Only mount types 'hostfs' and 'memfs' are accepted.", mountPoint.Target)
+			fmt.Printf("ERROR: '%s': Only mount types 'hostfs' and 'memfs' are accepted.\n", mountPoint.Target)
 			return fmt.Errorf("an invalid mount type was specified: %s", mountPoint.Type)
 		}
 
 		// Warn user that 'memfs' source does nothing
 		if mountPoint.Type == "memfs" && mountPoint.Source != "" && mountPoint.Source != "/" {
-			fmt.Printf("WARNING: '%s': The mount point of type 'memfs' specified a source directory, will be ignored.", mountPoint.Target)
+			fmt.Printf("WARNING: '%s': The mount point of type 'memfs' specified a source directory, will be ignored.\n", mountPoint.Target)
 		}
 
 		// Warn user that a read-only 'memfs' is useless
 		if mountPoint.Type == "memfs" && mountPoint.ReadOnly {
-			fmt.Printf("WARNING: '%s': The mount point of type 'memfs' is set as read-only, making it effectively useless. Check your configuration.", mountPoint.Target)
+			fmt.Printf("WARNING: '%s': The mount point of type 'memfs' is set as read-only, making it effectively useless. Check your configuration.\n", mountPoint.Target)
 		}
 
 		// Add already existing target to map of used targets for redefiniton checks

--- a/internal/premain/core/core.go
+++ b/internal/premain/core/core.go
@@ -96,7 +96,10 @@ func addEnvVars(config config.Config) error {
 
 	// Copy all environment variable definitions from the enclave config
 	for _, configEnvVar := range config.Env {
-		newEnvVars[configEnvVar.Name] = configEnvVar.Value
+		// Only create new environment variable if value is not empty
+		if configEnvVar.Value != "" {
+			newEnvVars[configEnvVar.Name] = configEnvVar.Value
+		}
 
 		// Check if we can copy the env var from host
 		if envVarFromHost := os.Getenv(configEnvVar.Name); configEnvVar.FromHost && envVarFromHost != "" {

--- a/internal/premain/core/core.go
+++ b/internal/premain/core/core.go
@@ -23,34 +23,31 @@ type Mounter interface {
 }
 
 // PreMain runs before the App's actual main routine and initializes the EGo enclave.
-func PreMain(payload string, mounter Mounter) ([]string, error) {
+func PreMain(payload string, mounter Mounter) error {
 	var config config.Config
 	if len(payload) > 0 {
 		// Load config from embedded payload
 		if err := json.Unmarshal([]byte(payload), &config); err != nil {
-			return nil, err
+			return err
 		}
 
 		// Perform mounts based on embedded config
 		if err := performMounts(config, mounter); err != nil {
-			return nil, err
+			return err
 		}
 	}
 
 	// Extract new environment variables
 	if err := addEnvVars(config); err != nil {
-		return nil, err
+		return err
 	}
 
 	// If program is running as a Marble, continue with Marblerun Premain.
 	if os.Getenv("EDG_EGO_PREMAIN") == "1" {
-		if err := premain.PreMain(); err != nil {
-			return nil, err
-		}
+		return premain.PreMain()
 	}
 
-	// Return new environment variables to the caller
-	return os.Environ(), nil
+	return nil
 }
 
 func performMounts(config config.Config, mounter Mounter) error {

--- a/internal/premain/core/core.go
+++ b/internal/premain/core/core.go
@@ -83,11 +83,14 @@ func addEnvVars(config config.Config) error {
 	existingEnvVars := os.Environ()
 	newEnvVars := make(map[string]string)
 
+	// Set OE_IS_ENCLAVE to 1
+	newEnvVars["OE_IS_ENCLAVE"] = "1"
+
 	// Copy all special EDG_ environment variables
 	for _, envVar := range existingEnvVars {
 		if strings.HasPrefix(envVar, "EDG_") {
 			splitString := strings.Split(envVar, "=")
-			newEnvVars[splitString[0]] = os.Getenv(splitString[0])
+			newEnvVars[splitString[0]] = splitString[1]
 		}
 	}
 

--- a/internal/premain/core/core_test.go
+++ b/internal/premain/core/core_test.go
@@ -44,18 +44,17 @@ func TestPremain(t *testing.T) {
 
 	// Supply valid payload, no Marble
 	mounter := assertionMounter{assert: assert, config: conf, usedTargets: make(map[string]bool)}
-	_, err := PreMain("", &mounter)
-	assert.NoError(err)
+	assert.NoError(PreMain("", &mounter))
+
 	// Supply valid payload, no Marble
 	payload, err := json.Marshal(conf)
 	require.NoError(err)
 	mounter = assertionMounter{assert: assert, config: conf, usedTargets: make(map[string]bool)}
-	_, err = PreMain(string(payload), &mounter)
-	assert.NoError(err)
+	assert.NoError(PreMain(string(payload), &mounter))
+
 	// Supply invalid payload, should fail
 	payload = []byte("blablarubbish")
-	_, err = PreMain(string(payload), &mounter)
-	assert.Error(err)
+	assert.Error(PreMain(string(payload), &mounter))
 }
 
 func TestPerformMounts(t *testing.T) {

--- a/internal/premain/core/core_test.go
+++ b/internal/premain/core/core_test.go
@@ -41,17 +41,18 @@ func TestPremain(t *testing.T) {
 
 	// Supply valid payload, no Marble
 	mounter := assertionMounter{assert: assert, config: conf, usedTargets: make(map[string]bool)}
-	assert.NoError(PreMain("", &mounter))
-
+	_, err := PreMain("", &mounter)
+	assert.NoError(err)
 	// Supply valid payload, no Marble
 	payload, err := json.Marshal(conf)
 	require.NoError(err)
 	mounter = assertionMounter{assert: assert, config: conf, usedTargets: make(map[string]bool)}
-	assert.NoError(PreMain(string(payload), &mounter))
-
+	_, err = PreMain(string(payload), &mounter)
+	assert.NoError(err)
 	// Supply invalid payload, should fail
 	payload = []byte("blablarubbish")
-	assert.Error(PreMain(string(payload), &mounter))
+	_, err = PreMain(string(payload), &mounter)
+	assert.Error(err)
 }
 
 func TestPerformMounts(t *testing.T) {

--- a/internal/premain/main.go
+++ b/internal/premain/main.go
@@ -11,6 +11,7 @@ import "C"
 import (
 	"os"
 	"syscall"
+	"unsafe"
 
 	"github.com/edgelesssys/ego/internal/premain/core"
 )
@@ -23,8 +24,9 @@ type SyscallMounter struct{}
 func main() {}
 
 //export ert_ego_premain
-func ert_ego_premain(argc *C.int, argv ***C.char, payload *C.char) {
-	if err := core.PreMain(C.GoString(payload), &SyscallMounter{}); err != nil {
+func ert_ego_premain(argc *C.int, argv ***C.char, payload *C.char) **C.char {
+	goNewEnviron, err := core.PreMain(C.GoString(payload), &SyscallMounter{})
+	if err != nil {
 		panic(err)
 	}
 
@@ -35,6 +37,16 @@ func ert_ego_premain(argc *C.int, argv ***C.char, payload *C.char) {
 
 	*argc = C.int(len(os.Args))
 	*argv = &cargs[0]
+
+	// Build and return new environ to use
+	cNewEnviron := C.malloc(C.size_t(len(goNewEnviron)) * C.size_t(unsafe.Sizeof(uintptr(0))))
+	cNewEnvironIndexable := (*[1<<30 - 1]*C.char)(cNewEnviron)
+
+	for index, value := range goNewEnviron {
+		cNewEnvironIndexable[index] = C.CString(value)
+	}
+
+	return (**C.char)(cNewEnviron)
 }
 
 // Mount for SyscallMounter redirects to syscall.Mount

--- a/src/enc.cpp
+++ b/src/enc.cpp
@@ -165,25 +165,8 @@ ert_args_t ert_get_args()
 
     assert(env);
 
-    //
-    // Keep all env vars that begin with EDG_
-    //
-
-    size_t edg_count = 0;
-
-    for (size_t i = 0; env[i]; ++i)
-    {
-        if (memcmp(env[i], "EDG_", 4) == 0)
-        {
-            env[edg_count] = env[i];
-            ++edg_count;
-        }
-    }
-
-    env[edg_count] = nullptr;
-
     ert_args_t result{};
-    result.envc = static_cast<int>(edg_count);
+    result.envc = args.envc;
     result.envp = env;
 
     //

--- a/src/enc.cpp
+++ b/src/enc.cpp
@@ -107,8 +107,6 @@ int emain()
 
     if (!is_marblerun)
     {
-        _argc = ert_get_argc();
-
         const char* const cwd = getenv("EDG_CWD");
         if (!cwd || !*cwd || chdir(cwd) != 0)
         {

--- a/src/enc.cpp
+++ b/src/enc.cpp
@@ -26,7 +26,7 @@ using namespace ert;
 static int _argc;
 static char** _argv;
 
-extern "C" void ert_ego_premain(
+extern "C" char** ert_ego_premain(
     int* argc,
     char*** argv,
     const char* payload_data);
@@ -99,18 +99,15 @@ int emain()
         payload_data_pair.second);
 
     _log_verbose("invoking premain");
-    ert_ego_premain(&_argc, &_argv, payload_data.c_str());
+    auto new_environ = ert_ego_premain(&_argc, &_argv, payload_data.c_str());
     _log_verbose("premain done");
 
     // get args and env
-    if (is_marblerun)
-    {
-        _argv = _merge_argv_env(_argc, _argv, environ);
-    }
-    else
+    _argv = _merge_argv_env(_argc, _argv, new_environ);
+
+    if (!is_marblerun)
     {
         _argc = ert_get_argc();
-        _argv = ert_get_argv();
 
         const char* const cwd = getenv("EDG_CWD");
         if (!cwd || !*cwd || chdir(cwd) != 0)


### PR DESCRIPTION
This PR adds support for user-definable passing of environment variables to the enclave.

Example for the enclave.json:
```json
{
    "exe": "integration-test",
    "key": "private.pem",
    "debug": true,
    "heapSize": 512,
    "productID": 1,
    "securityVersion": 1,
    "env": [
        {
            "name": "HELLO_WORLD",
            "value": "Hi!"
        },
        {
            "name": "PWD",
            "fromHost": true
        }
    ]
}
```

`fromHost` defines if an environment variable should be copied from the host, if it exists. If it does not exist, it will fall back to a given `value` as long as it's defined **and** not empty. If it's not existing on the host and not defined, it will not be created and throw a warning, but pass the validity checks.

And as before, "EDG_" environment variables will be preserved, all other ones will be flushed when entering the main application.

Feedback appreciated, especially for the Go -> C++ data flow. :)