### PR TITLE
AB#700: Expose in-memory filesystem by default

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/edgelesssys/edgelessrt-dev:ci
+      image: ghcr.io/edgelesssys/edgelessrt-dev:nightly
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/edgelesssys/edgelessrt-dev:nightly
+      image: ghcr.io/edgelesssys/edgelessrt-dev:ci
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/cmd/integration-test/enclave.json
+++ b/cmd/integration-test/enclave.json
@@ -24,7 +24,7 @@
         },
         {
             "name": "PWD",
-            "fromHost": true
+            "value": "/data"
         }
     ]
 }

--- a/cmd/integration-test/main.go
+++ b/cmd/integration-test/main.go
@@ -82,7 +82,7 @@ func testEnvVars(assert *assert.Assertions, require *require.Assertions) {
 	assert.Equal("Let's hope this passes the test :)", os.Getenv("HELLO_WORLD"))
 	currentPwd, err := os.Getwd()
 	require.NoError(err)
-	assert.Equal(currentPwd, "/data")
+	assert.Equal("/data", currentPwd)
 
 	// Test if OE_IS_ENCLAVE is set
 	assert.Equal("1", os.Getenv("OE_IS_ENCLAVE"))

--- a/cmd/integration-test/main.go
+++ b/cmd/integration-test/main.go
@@ -82,7 +82,7 @@ func testEnvVars(assert *assert.Assertions, require *require.Assertions) {
 	assert.Equal("Let's hope this passes the test :)", os.Getenv("HELLO_WORLD"))
 	currentPwd, err := os.Getwd()
 	require.NoError(err)
-	assert.Equal(currentPwd, "/")
+	assert.Equal(currentPwd, "/data")
 
 	// Test if OE_IS_ENCLAVE is set
 	assert.Equal("1", os.Getenv("OE_IS_ENCLAVE"))

--- a/cmd/integration-test/main.go
+++ b/cmd/integration-test/main.go
@@ -7,6 +7,7 @@
 package main
 
 import (
+	"io"
 	"io/ioutil"
 	"log"
 	"os"
@@ -29,15 +30,49 @@ func main() {
 }
 
 func testFileSystemMounts(assert *assert.Assertions, require *require.Assertions) {
+	// Check if root directory is empty
+	log.Println("Testing default memfs mount...")
+	log.Println("Check if exposed filesystem only contains 'edg' for memfs mounts...")
+	dirContent, err := os.Open("/")
+	require.NoError(err)
+	content, err := dirContent.Readdirnames(2)
+	assert.NoError(err)
+	assert.Len(content, 1)
+	assert.Equal("edg", content[0])
+
+	// Check if we can write and read to the root memfs
+	log.Println("Checking I/O of memfs...")
+	const localTest = "This is a test!"
+	require.NoError(ioutil.WriteFile("test-root.txt", []byte(localTest), 0755))
+	fileContent, err := ioutil.ReadFile("test-root.txt")
+	require.NoError(err)
+	assert.Equal(localTest, string(fileContent))
+
+	// Check hostfs mounts specified in manifest
 	log.Println("Testing hostfs mounts...")
-	fileContent, err := ioutil.ReadFile("/data/test-file.txt")
+	fileContent, err = ioutil.ReadFile("/data/test-file.txt")
 	require.NoError(err)
 	assert.Equal("It works!", string(fileContent))
 
+	// Check memfs mounts specified in manifest
 	log.Println("Testing memfs mounts...")
+
+	// Check if new memfs mount does not contain any files from the root filesystem
+	dirContent, err = os.Open("/memfs")
+	require.NoError(err)
+	_, err = dirContent.Readdirnames(1)
+	assert.ErrorIs(io.EOF, err)
+
+	// Check if we can write and read to the mounted memfs
 	err = ioutil.WriteFile("/memfs/test-file.txt", fileContent, 0)
 	require.NoError(err)
 	newFileContent, err := ioutil.ReadFile("/memfs/test-file.txt")
+	require.NoError(err)
+	assert.Equal("It works!", string(newFileContent))
+
+	// Check if we can read to the mounted memfs from root explicitly
+	newFileContent, err = ioutil.ReadFile("/edg/mnt/memfs/test-file.txt")
+	require.NoError(err)
 	assert.Equal("It works!", string(newFileContent))
 }
 
@@ -47,7 +82,7 @@ func testEnvVars(assert *assert.Assertions, require *require.Assertions) {
 	assert.Equal("Let's hope this passes the test :)", os.Getenv("HELLO_WORLD"))
 	currentPwd, err := os.Getwd()
 	require.NoError(err)
-	assert.Equal(currentPwd, os.Getenv("PWD"))
+	assert.Equal(currentPwd, "/")
 
 	// Test if OE_IS_ENCLAVE is set
 	assert.Equal("1", os.Getenv("OE_IS_ENCLAVE"))

--- a/doc/ego_cli.md
+++ b/doc/ego_cli.md
@@ -152,8 +152,12 @@ The developer should increment the `securityVersion` (SGX: ISVSVN) whenever a se
 
   * `source` (required for `hostfs`): The directory from host file system which should be mounted in the enclave when using `hostfs`. For `memfs`, this value will be ignored and can be omitted.
   * `target` (required): Defines the mount path in the enclave.
-  * `type` (required): Either `hostfs` if you want to mount a path from the host's file system in the enclave, or `memfs` if you want to use a temporary file system similar to *tmpfs* on UNIX systems.
+  * `type` (required): Either `hostfs` if you want to mount a path from the host's file system in the enclave, or `memfs` if you want to use a temporary file system similar to *tmpfs* on UNIX systems, with your data stored in the secure memory environment of the enclave.
   * `readOnly`: Can be `true` or `false` depending on if you want to mount the path as read-only or read-write. When omitted, will default to read-write.
+
+By default, `/` is initialized as an empty `memfs` file system. To expose certain directories to the enclave, you can use the `hostfs` mounts with the options mentioned above. You can also choose to define additional `memfs` mount points, but note that there is no explicit isolation between them. They can be accessed either via the path specified in `target` or also via `/edg/mnt/<target>`, which is where the files of the additional `memfs` mount are stored internally.
+
+**It is not recommended to use the mount options to remount '/' as `hostfs` other than for testing purposes**. You might involuntarily expose files to the host which should stay inside the enclave, risking the confidentiality of your data.
 
 `env` holds environment variables to set or take over from the host inside the enclave. By default, all environment variables not starting with `EDG_` are dropped when entering the enclave (except for `OE_IS_ENCLAVE`, which can be used as an indicator that we are inside an enclave).
 

--- a/doc/ego_cli.md
+++ b/doc/ego_cli.md
@@ -164,3 +164,5 @@ By default, `/` is initialized as an empty `memfs` file system. To expose certai
   * `name` (required): The name of the environment variable (what you put before `=`)
   * `value` (required if not `fromHost`): The value of the environment variable (what you put after `=`)
   * `fromHost`: When set to `true`, the current value of the requested environment variable will be copied over if it exists on the host. If the host does not hold this variable, it will either fall back to the value set in `value` (if it exists), or will not be created at all.
+
+A special environment variable is `PWD`. Depending on the mount options you have set in your configuration, you can set the initial working directory of your enclave by specifying your desired path as value for `PWD`. Note that this directory needs to exist in the context of the enclave, not your host file system.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/edgelesssys/ego
 go 1.14
 
 require (
-	github.com/edgelesssys/marblerun v0.3.2-0.20210419145600-46982f4b888e
+	github.com/edgelesssys/marblerun v0.3.2-0.20210420103257-91e2ec7e5140
 	github.com/google/go-cmp v0.5.5
 	github.com/spf13/afero v1.5.1
 	github.com/stretchr/testify v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/edgelesssys/ego
 go 1.14
 
 require (
-	github.com/edgelesssys/marblerun v0.3.1
+	github.com/edgelesssys/marblerun v0.3.2-0.20210419145600-46982f4b888e
 	github.com/google/go-cmp v0.5.5
 	github.com/spf13/afero v1.5.1
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -164,8 +164,8 @@ github.com/edgelesssys/era v0.3.0/go.mod h1:5OB1KAIEjbCqrs+5VOK5Im28wbcNiyc/RD3A
 github.com/edgelesssys/ertgolib v0.1.1/go.mod h1:QV27eWmoYHCNMkPMnz2XcER13+XdhPyG5qLQu5iDL0I=
 github.com/edgelesssys/ertgolib v0.1.5-0.20210208080427-0d5e24e2f855/go.mod h1:1E8jAgXZp9wyP3n43wCsLCiEGXxjBQ35+uzxUkypBNs=
 github.com/edgelesssys/marblerun v0.2.1-0.20210312084731-95118a77f617/go.mod h1:8HWnA9SmYZeK3Jmq0meqOwp6/avuLAMTMgtwRlnhRRw=
-github.com/edgelesssys/marblerun v0.3.2-0.20210419145600-46982f4b888e h1:1G3BSVqKia2i+WI3WMd8BBBbCroOtkTYwlwto99uO7s=
-github.com/edgelesssys/marblerun v0.3.2-0.20210419145600-46982f4b888e/go.mod h1:X+l1OC7rrRqwbmqK4OahspGCann/WidGocuRJzHRVWg=
+github.com/edgelesssys/marblerun v0.3.2-0.20210420103257-91e2ec7e5140 h1:V1zqGpn0VHwfCN2+fzdKvUektrs11yq9coVAfMIeDzg=
+github.com/edgelesssys/marblerun v0.3.2-0.20210420103257-91e2ec7e5140/go.mod h1:X+l1OC7rrRqwbmqK4OahspGCann/WidGocuRJzHRVWg=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=

--- a/go.sum
+++ b/go.sum
@@ -162,12 +162,10 @@ github.com/edgelesssys/ego v0.1.2/go.mod h1:2w3REN6B9YUdc98PF8d5jh6cmGNHORbKaJxT
 github.com/edgelesssys/era v0.1.1-0.20210209072546-fb6c08a3562c/go.mod h1:rEv/EPEWTUpu8gGOUWp97Bk1kFFvgYwcJY0yA4cKG8U=
 github.com/edgelesssys/era v0.3.0/go.mod h1:5OB1KAIEjbCqrs+5VOK5Im28wbcNiyc/RD3AQtuw/sM=
 github.com/edgelesssys/ertgolib v0.1.1/go.mod h1:QV27eWmoYHCNMkPMnz2XcER13+XdhPyG5qLQu5iDL0I=
-github.com/edgelesssys/ertgolib v0.1.5-0.20210208080427-0d5e24e2f855 h1:3iTzGhF0FJf5ZFDPfU54NAfObJwlexJYFR3ShITYlEk=
 github.com/edgelesssys/ertgolib v0.1.5-0.20210208080427-0d5e24e2f855/go.mod h1:1E8jAgXZp9wyP3n43wCsLCiEGXxjBQ35+uzxUkypBNs=
-github.com/edgelesssys/marblerun v0.2.1-0.20210312084731-95118a77f617 h1:ytOrUpvv1t5L/kfmq8JS5Qrcr1bdRGP34NO/kGoomNw=
 github.com/edgelesssys/marblerun v0.2.1-0.20210312084731-95118a77f617/go.mod h1:8HWnA9SmYZeK3Jmq0meqOwp6/avuLAMTMgtwRlnhRRw=
-github.com/edgelesssys/marblerun v0.3.1 h1:TmfeVzSofVk2eduaoSdgahZpNZCIM3vVUqbQa3MVIVI=
-github.com/edgelesssys/marblerun v0.3.1/go.mod h1:X+l1OC7rrRqwbmqK4OahspGCann/WidGocuRJzHRVWg=
+github.com/edgelesssys/marblerun v0.3.2-0.20210419145600-46982f4b888e h1:1G3BSVqKia2i+WI3WMd8BBBbCroOtkTYwlwto99uO7s=
+github.com/edgelesssys/marblerun v0.3.2-0.20210419145600-46982f4b888e/go.mod h1:X+l1OC7rrRqwbmqK4OahspGCann/WidGocuRJzHRVWg=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
@@ -360,7 +358,6 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxv
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
-github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
@@ -699,7 +696,6 @@ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200421231249-e086a090c8fd/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
-golang.org/x/net v0.0.0-20200625001655-4c5254603344 h1:vGXIOMxbNfDTk/aXCmfdLgkrSV+Z2tcbze+pEc3v5W4=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b h1:uwuIcX0g4Yl1NC5XAz37xsr2lTtcqevgzYNVt49waME=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
@@ -757,7 +753,6 @@ golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211 h1:9UQO31fZ+0aKQOFldThf7BKPMJTiBfWycGh/u3UoO88=
 golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd h1:5CtCZbICpIOFdgO940moixOPjc0178IU44m4EjOO5IY=
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -765,7 +760,6 @@ golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fq
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
-golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.4 h1:0YWbFKbhXG/wIiuHDSKpS0Iy7FSA+u45VtBMfQcFTTc=
 golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
@@ -819,7 +813,6 @@ golang.org/x/tools v0.0.0-20200505023115-26f46d2f7ef8/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200616133436-c1934b75d054/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -862,7 +855,6 @@ google.golang.org/genproto v0.0.0-20200212174721-66ed5ce911ce/go.mod h1:55QSHmfG
 google.golang.org/genproto v0.0.0-20200224152610-e50cd9704f63/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200305110556-506484158171/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200423170343-7949de9c1215/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
-google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 h1:+kGHl1aib/qcwaRi1CbqBZ1rk19r85MNUf8HaBghugY=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/genproto v0.0.0-20201110150050-8816d57aaa9a h1:pOwg4OoaRYScjmR4LlLgdtnyoHYTSAVhhqe5uPdpII8=
 google.golang.org/genproto v0.0.0-20201110150050-8816d57aaa9a/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -91,6 +91,10 @@ func (c *Config) Validate() error {
 			fmt.Printf("WARNING: '%s': The mount point of type 'memfs' is set as read-only, making it effectively useless. Check your configuration.\n", mountPoint.Target)
 		}
 
+		if mountPoint.Target == "/" && mountPoint.Type == "hostfs" {
+			fmt.Printf("WARNING: '%s' is defined as 'hostfs'. This might be insecure, please make sure you explicitly allow the paths you want to expose to the enclave.\n", mountPoint.Target)
+		}
+
 		// Add already existing target to map of used targets for redefiniton checks
 		alreadyUsedMountPoints[mountPoint.Target] = true
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -61,7 +61,7 @@ func TestValidateFileSystemMounts(t *testing.T) {
 	config.Mounts[1] = FileSystemMount{Source: "/home/benjaminfranklin", Target: "/data", Type: "hostfs", ReadOnly: false}
 	assert.NoError(config.Validate())
 
-	// Specify source path for memfs & set it as read only. Really makes no sense and throws warnings, but should pass.
+	// Specify source path for memfs, should pass.
 	config.Mounts[0] = FileSystemMount{Source: "/blabla", Target: "/data_memfs", Type: "memfs", ReadOnly: true}
 	assert.NoError(config.Validate())
 

--- a/internal/premain/core/core.go
+++ b/internal/premain/core/core.go
@@ -48,10 +48,7 @@ type Mounter interface {
 // PreMain runs before the App's actual main routine and initializes the EGo enclave.
 func PreMain(payload string, mounter Mounter, fs afero.Fs) error {
 	// Check if we run as a Marble or a normal EGo application
-	var isMarble bool
-	if os.Getenv(marblerunEnvVarFlag) == "1" {
-		isMarble = true
-	}
+	isMarble := os.Getenv(marblerunEnvVarFlag) == "1"
 
 	// Perform predefined mounts
 	if err := performPredefinedMounts(mounter, isMarble); err != nil {

--- a/internal/premain/core/core.go
+++ b/internal/premain/core/core.go
@@ -58,7 +58,7 @@ func PreMain(payload string, mounter Mounter, fs afero.Fs) error {
 
 	// If program is running as a Marble, continue with Marblerun Premain.
 	if os.Getenv("EDG_EGO_PREMAIN") == "1" {
-		return premain.PreMain()
+		return premain.PreMainEgo()
 	}
 
 	return nil

--- a/internal/premain/core/core.go
+++ b/internal/premain/core/core.go
@@ -86,7 +86,7 @@ func performMounts(config config.Config, mounter Mounter, fs afero.Fs) error {
 			if err := mounter.Unmount("/", syscall.MNT_FORCE); err != nil {
 				return err
 			}
-			fmt.Println("WARNING: Remounted '/' to hostfs. This is insecure. Please only use this for testing purposes.")
+			fmt.Println("WARNING: Remounted '/' to hostfs. This might be insecure. Please only use this for testing purposes.")
 			// Remounting memfs to /edg/mnt, we just keep it as base for memfs mounts
 			if err := mounter.Mount("/", "/", "oe_host_file_system", 0, ""); err != nil {
 				return err

--- a/internal/premain/core/core_test.go
+++ b/internal/premain/core/core_test.go
@@ -89,20 +89,19 @@ func TestPerformMounts(t *testing.T) {
 	}
 
 	mounter := assertionMounter{assert: assert, config: conf, usedTargets: make(map[string]bool), remountAsHostFS: false}
-	assert.NoError(performMounts(*conf, &mounter, fs))
+	assert.NoError(performUserMounts(*conf, &mounter, fs))
 
 	conf.Mounts = []config.FileSystemMount{{Source: "/home/benjaminfranklin", Target: "/data", Type: "rubbishfs", ReadOnly: true}}
-	assert.Error(performMounts(*conf, &mounter, fs))
+	assert.Error(performUserMounts(*conf, &mounter, fs))
 
 	// Test '/' as host fs special case. Should work without an error, but we do not recommend doing this
 	mounter = assertionMounter{assert: assert, config: confWithRemount, usedTargets: make(map[string]bool), remountAsHostFS: true}
-	assert.NoError(performMounts(*confWithRemount, &mounter, fs))
+	assert.NoError(performUserMounts(*confWithRemount, &mounter, fs))
 }
 
 func (a *assertionMounter) Mount(source string, target string, filesystem string, flags uintptr, data string) error {
 	// Skip special mount calls for unit test, as we cannot check them against the configuration
 	if target == "/" {
-		a.assert.EqualValues(mountTypeHostFS, filesystem)
 		return nil
 	}
 	if target == "/edg/mnt" {

--- a/internal/premain/main.go
+++ b/internal/premain/main.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 
 	"github.com/edgelesssys/ego/internal/premain/core"
+	"github.com/spf13/afero"
 )
 
 var cargs []*C.char
@@ -24,7 +25,7 @@ func main() {}
 
 //export ert_ego_premain
 func ert_ego_premain(argc *C.int, argv ***C.char, payload *C.char) {
-	if err := core.PreMain(C.GoString(payload), &SyscallMounter{}); err != nil {
+	if err := core.PreMain(C.GoString(payload), &SyscallMounter{}, afero.NewOsFs()); err != nil {
 		panic(err)
 	}
 
@@ -40,4 +41,9 @@ func ert_ego_premain(argc *C.int, argv ***C.char, payload *C.char) {
 // Mount for SyscallMounter redirects to syscall.Mount
 func (m *SyscallMounter) Mount(source string, target string, filesystem string, flags uintptr, data string) error {
 	return syscall.Mount(source, target, filesystem, flags, data)
+}
+
+// Unmount for SyscallMounter redirects to syscall.Unmount
+func (m *SyscallMounter) Unmount(target string, flags int) error {
+	return syscall.Unmount(target, flags)
 }

--- a/src/enc.cpp
+++ b/src/enc.cpp
@@ -96,7 +96,7 @@ int emain()
     // Assume environment variables & mounts were performed in ert_ego_premain
 
     // If user specified PWD, try to set is as current working directory
-    // Otherwise fall back to / (which should be memfs by default)
+    // Otherwise we should be in / (which should be memfs by default)
     const char* const pwd = getenv("PWD");
 
     if (pwd && chdir(pwd) != 0)
@@ -104,12 +104,6 @@ int emain()
         _log("cannot set cwd to specified pwd");
         return EXIT_FAILURE;
     }
-    if (!pwd && chdir("/") != 0)
-    {
-        _log("cannot set cwd to root");
-        return EXIT_FAILURE;
-    }
-
     // cleanup go runtime
     _log_verbose("cleaning up the old goruntime: go_rc_kill_threads");
     go_rc_kill_threads();

--- a/src/enc.cpp
+++ b/src/enc.cpp
@@ -115,13 +115,10 @@ int emain()
     // get args and env
     _argv = _merge_argv_env(_argc, _argv, environ);
 
-    if (!is_marblerun)
+    if (chdir(memfs_mount_path) != 0)
     {
-        if (chdir(memfs_mount_path) != 0)
-        {
-            _log("cannot set cwd");
-            return EXIT_FAILURE;
-        }
+        _log("cannot set cwd");
+        return EXIT_FAILURE;
     }
 
     // cleanup go runtime


### PR DESCRIPTION
Prerequisite: #https://github.com/edgelesssys/edgelessrt/pull/36

I think it might be worth discussing if there are any scenarios where we should prevent the user from exposing sensitive data from the host filesystem. Right now, I allowed the user to remount '/' as any part of the host filesystem, though I am not sure if we actually want to keep this. 

I think this might be useful for debugging, and there could also be many potential scenarios where this is used safely, so how do we handle that? One idea I had was that we could maybe bind this to the 'Debug' flag in the configuration and disable root mounts for non-debuggable applications, but yeah, this does not stop anyone from still mounting something potentially unsafe at other locations...

@thomasten @m1ghtym0 Any ideas how to handle this case?