### PR TITLE
Adjust example enclave.json for default memfs

### DIFF
--- a/doc/ego_cli.md
+++ b/doc/ego_cli.md
@@ -123,11 +123,11 @@ Here is an example configuration:
     "env": [
         {
             "name": "LANG",
-            "value": "en_US.UTF-8"
+            "fromHost": true
         },
         {
             "name": "PWD",
-            "fromHost": true
+            "value": "/data"
         }
     ]
 }


### PR DESCRIPTION
Guess I forgot to change this yesterday, so here's an updated example which makes more sense for the new default mount.