### PR TITLE
Marblerun: Rename intermediate to root CA

### DIFF
--- a/marble/marble.go
+++ b/marble/marble.go
@@ -56,7 +56,7 @@ func generateFromEnv() (tls.Certificate, *x509.CertPool, error) {
 	if err != nil {
 		return tls.Certificate{}, nil, err
 	}
-	rootCA, err := getByteEnv(MarbleEnvironmentRootCA)
+	marbleRootCA, err := getByteEnv(MarbleEnvironmentRootCA)
 	if err != nil {
 		return tls.Certificate{}, nil, err
 	}
@@ -66,8 +66,8 @@ func generateFromEnv() (tls.Certificate, *x509.CertPool, error) {
 	}
 
 	roots := x509.NewCertPool()
-	if !roots.AppendCertsFromPEM(rootCA) {
-		return tls.Certificate{}, nil, fmt.Errorf("cannot append rootCA to CertPool")
+	if !roots.AppendCertsFromPEM(marbleRootCA) {
+		return tls.Certificate{}, nil, fmt.Errorf("cannot append marbleRootCA to CertPool")
 	}
 
 	tlsCert, err := tls.X509KeyPair(certChain, leafPrivk)

--- a/marble/marble.go
+++ b/marble/marble.go
@@ -17,8 +17,8 @@ import (
 // MarbleEnvironmentCertificateChain contains the name of the environment variable holding a marble-specifc PEM encoded certificate
 const MarbleEnvironmentCertificateChain = "MARBLE_PREDEFINED_MARBLE_CERTIFICATE_CHAIN"
 
-// MarbleEnvironmentIntermediateCA contains the name of the environment variable holding a PEM encoded root certificate
-const MarbleEnvironmentIntermediateCA = "MARBLE_PREDEFINED_INTERMEDIATE_CA"
+// MarbleEnvironmentRootCA contains the name of the environment variable holding a PEM encoded root certificate
+const MarbleEnvironmentRootCA = "MARBLE_PREDEFINED_ROOT_CA"
 
 // MarbleEnvironmentPrivateKey contains the name of the environment variable holding a PEM encoded private key belonging to the marble-specific certificate
 const MarbleEnvironmentPrivateKey = "MARBLE_PREDEFINED_PRIVATE_KEY"
@@ -56,7 +56,7 @@ func generateFromEnv() (tls.Certificate, *x509.CertPool, error) {
 	if err != nil {
 		return tls.Certificate{}, nil, err
 	}
-	intermediateCA, err := getByteEnv(MarbleEnvironmentIntermediateCA)
+	rootCA, err := getByteEnv(MarbleEnvironmentRootCA)
 	if err != nil {
 		return tls.Certificate{}, nil, err
 	}
@@ -66,8 +66,8 @@ func generateFromEnv() (tls.Certificate, *x509.CertPool, error) {
 	}
 
 	roots := x509.NewCertPool()
-	if !roots.AppendCertsFromPEM(intermediateCA) {
-		return tls.Certificate{}, nil, fmt.Errorf("cannot append intermediateCA as rootCA to CertPool")
+	if !roots.AppendCertsFromPEM(rootCA) {
+		return tls.Certificate{}, nil, fmt.Errorf("cannot append rootCA to CertPool")
 	}
 
 	tlsCert, err := tls.X509KeyPair(certChain, leafPrivk)

--- a/marble/marble_test.go
+++ b/marble/marble_test.go
@@ -67,7 +67,7 @@ func TestGarbageEnviromentVars(t *testing.T) {
 	assert := assert.New(t)
 
 	// Set environment variables
-	os.Setenv(MarbleEnvironmentIntermediateCA, "this")
+	os.Setenv(MarbleEnvironmentRootCA, "this")
 	os.Setenv(MarbleEnvironmentCertificateChain, "is")
 	os.Setenv(MarbleEnvironmentPrivateKey, "some serious garbage")
 
@@ -134,14 +134,14 @@ func setupTest(require *require.Assertions) {
 	privKeyPem := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privKey})
 
 	// Set environment variables
-	os.Setenv(MarbleEnvironmentIntermediateCA, string(caCertPem))
+	os.Setenv(MarbleEnvironmentRootCA, string(caCertPem))
 	os.Setenv(MarbleEnvironmentCertificateChain, string(leafCertPem))
 	os.Setenv(MarbleEnvironmentPrivateKey, string(privKeyPem))
 }
 
 func resetEnv() {
 	// Clean up used environment variables, otherwise they stay set!
-	os.Unsetenv(MarbleEnvironmentIntermediateCA)
+	os.Unsetenv(MarbleEnvironmentRootCA)
 	os.Unsetenv(MarbleEnvironmentCertificateChain)
 	os.Unsetenv(MarbleEnvironmentPrivateKey)
 }


### PR DESCRIPTION
### Related Issue or purpose 
- https://github.com/edgelesssys/marblerun/pull/177

### Proposed Changes
- Rename intermediateCA -> rootCA 

### Additional Info 
The Marble context only knows the leaf and a root certificate.
Only in the Coordinator context, this certificate is actually an intermediate.
Naming it accordingly simplifies this from a Marble's perspective.
