### PR TITLE
adjusted cloned branch version, seperated env export

### DIFF
--- a/samples/vault/README.md
+++ b/samples/vault/README.md
@@ -34,7 +34,7 @@ export VAULT_ADDR=http://127.0.0.1:8200
 export VAULT_TOKEN=mytoken
 ```
 
-Use it from another terminal:
+Then use it:
 ```sh
 $ ./vault kv put secret/hello foo=world
 

--- a/samples/vault/README.md
+++ b/samples/vault/README.md
@@ -28,7 +28,7 @@ Then you can run Vault:
 ego run vault server -dev -dev-no-store-token -dev-root-token-id mytoken
 ```
 
-Export the environment variables:
+Open another terminal and export the environment variables:
 ```sh
 export VAULT_ADDR=http://127.0.0.1:8200
 export VAULT_TOKEN=mytoken

--- a/samples/vault/README.md
+++ b/samples/vault/README.md
@@ -3,7 +3,7 @@ This sample shows how to port an existing Go application to EGo.
 
 First clone the repo:
 ```sh
-git clone --depth=1 --branch=release/1.6.x https://github.com/hashicorp/vault
+git clone --depth=1 --branch=v1.6.3 https://github.com/hashicorp/vault
 cd vault
 ```
 

--- a/samples/vault/README.md
+++ b/samples/vault/README.md
@@ -3,7 +3,7 @@ This sample shows how to port an existing Go application to EGo.
 
 First clone the repo:
 ```sh
-git clone --depth=1 --branch=v1.6.3 https://github.com/hashicorp/vault
+git clone --depth=1 --branch=release/1.6.x https://github.com/hashicorp/vault
 cd vault
 ```
 
@@ -28,11 +28,14 @@ Then you can run Vault:
 ego run vault server -dev -dev-no-store-token -dev-root-token-id mytoken
 ```
 
+Export the environment variables:
+```sh
+export VAULT_ADDR=http://127.0.0.1:8200
+export VAULT_TOKEN=mytoken
+```
+
 Use it from another terminal:
 ```sh
-$ export VAULT_ADDR=http://127.0.0.1:8200
-$ export VAULT_TOKEN=mytoken
-
 $ ./vault kv put secret/hello foo=world
 
 Key              Value


### PR DESCRIPTION
### Proposed changes
- Change the cloned branch from `v1.6.3` to `release/1.6.x`
- Seperate the exports in samples/vault/README.md so it is easier to copy them

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->
