### PR TITLE
add libcrypto dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,18 @@ The easiest way to install EGo is via the Snap:
 sudo snap install ego-dev --classic
 ```
 
+You also need `gcc` and `libcrypto`. On Ubuntu install them with:
+```sh
+sudo apt install build-essential libssl-dev
+```
+
 ### Install the DEB package
 If you're on Ubuntu 18.04 or above, you can install the DEB package:
 ```bash
 wget -qO- https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add
 sudo add-apt-repository "deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu `lsb_release -cs` main"
 wget https://github.com/edgelesssys/ego/releases/download/v0.2.2/ego_0.2.2_amd64.deb
-sudo apt install ./ego_0.2.2_amd64.deb build-essential
+sudo apt install ./ego_0.2.2_amd64.deb build-essential libssl-dev
 ```
 
 ### Build from source

--- a/eclient/doc.go
+++ b/eclient/doc.go
@@ -9,5 +9,8 @@ Package eclient provides functionality for Go programs that interact with enclav
 
 Use this package for programs that don't run in an enclave themselves but interact with
 enclaved programs. Those non-enclaved programs are often called third parties or relying parties.
+
+This package requires libcrypto. On Ubuntu install it with:
+	sudo apt install libssl-dev
 */
 package eclient


### PR DESCRIPTION
libcrypto is not only needed by the single sample, so let's add it to the install instructions. (replaces #70)