### PR TITLE
AB#1063: Pass to-be-filtered host environment to Go as variable

### DIFF
--- a/ego/premain/main.go
+++ b/ego/premain/main.go
@@ -12,6 +12,7 @@ import (
 	"ego/premain/core"
 	"os"
 	"syscall"
+	"unsafe"
 
 	"github.com/spf13/afero"
 )
@@ -24,8 +25,9 @@ type SyscallMounter struct{}
 func main() {}
 
 //export ert_ego_premain
-func ert_ego_premain(argc *C.int, argv ***C.char, payload *C.char) {
-	if err := core.PreMain(C.GoString(payload), &SyscallMounter{}, afero.NewOsFs()); err != nil {
+func ert_ego_premain(argc *C.int, argv ***C.char, envc *C.int, envp ***C.char, payload *C.char) {
+	originalEnviron := convertEnvironmentToGoStringArray(*envc, *envp)
+	if err := core.PreMain(C.GoString(payload), &SyscallMounter{}, afero.NewOsFs(), originalEnviron); err != nil {
 		panic(err)
 	}
 
@@ -46,4 +48,15 @@ func (m *SyscallMounter) Mount(source string, target string, filesystem string, 
 // Unmount for SyscallMounter redirects to syscall.Unmount
 func (m *SyscallMounter) Unmount(target string, flags int) error {
 	return syscall.Unmount(target, flags)
+}
+
+// Adapted from: https://stackoverflow.com/a/36189294
+func convertEnvironmentToGoStringArray(envc C.int, envp **C.char) []string {
+	length := int(envc)
+	tmpSlice := (*[1 << 30]*C.char)(unsafe.Pointer(envp))[:length:length]
+	goStrings := make([]string, length)
+	for i, s := range tmpSlice {
+		goStrings[i] = C.GoString(s)
+	}
+	return goStrings
 }

--- a/ego/premain/main.go
+++ b/ego/premain/main.go
@@ -25,8 +25,8 @@ type SyscallMounter struct{}
 func main() {}
 
 //export ert_ego_premain
-func ert_ego_premain(argc *C.int, argv ***C.char, envc *C.int, envp ***C.char, payload *C.char) {
-	originalEnviron := convertEnvironmentToGoStringArray(*envc, *envp)
+func ert_ego_premain(argc *C.int, argv ***C.char, envc C.int, envp **C.char, payload *C.char) {
+	originalEnviron := convertEnvironmentToGoStringArray(envc, envp)
 	if err := core.PreMain(C.GoString(payload), &SyscallMounter{}, afero.NewOsFs(), originalEnviron); err != nil {
 		panic(err)
 	}

--- a/src/enc.cpp
+++ b/src/enc.cpp
@@ -24,14 +24,14 @@ using namespace std;
 using namespace ert;
 static int _argc;
 static char** _argv;
-static int envc;
-static char** envp = nullptr;
+static int _envc;
+static char** _envp;
 
 extern "C" void ert_ego_premain(
     int* argc,
     char*** argv,
-    int* envc,
-    char*** envp,
+    int envc,
+    char** envp,
     const char* payload_data);
 static char** _merge_argv_env(int argc, char** argv, char** envp);
 
@@ -92,7 +92,7 @@ int emain()
         payload_data_pair.second);
 
     _log_verbose("invoking premain");
-    ert_ego_premain(&_argc, &_argv, &envc, &envp, payload_data.c_str());
+    ert_ego_premain(&_argc, &_argv, _envc, _envp, payload_data.c_str());
     _log_verbose("premain done");
     ert_init_ttls(getenv("MARBLE_TTLS_CONFIG"));
 
@@ -145,10 +145,10 @@ ert_args_t ert_get_args()
      avoid the host messing with the Go premain with GODEBUG and similar.
     */
     ert_copy_strings_from_host_to_enclave(
-        args.envp, &envp, static_cast<size_t>(args.envc));
+        args.envp, &_envp, static_cast<size_t>(args.envc));
 
-    assert(envp);
-    envc = args.envc;
+    assert(_envp);
+    _envc = args.envc;
 
     ert_args_t result{};
 

--- a/src/enc.cpp
+++ b/src/enc.cpp
@@ -24,10 +24,14 @@ using namespace std;
 using namespace ert;
 static int _argc;
 static char** _argv;
+static int envc;
+static char** envp = nullptr;
 
 extern "C" void ert_ego_premain(
     int* argc,
     char*** argv,
+    int* envc,
+    char*** envp,
     const char* payload_data);
 static char** _merge_argv_env(int argc, char** argv, char** envp);
 
@@ -46,7 +50,8 @@ static void _log(string_view s)
 
 static void _log_verbose(string_view s)
 {
-    static const bool verbose_enabled = [] {
+    static const bool verbose_enabled = []
+    {
         const char* const env_verbose = getenv(_verbose_env_key);
         return env_verbose && *env_verbose == '1';
     }();
@@ -87,7 +92,7 @@ int emain()
         payload_data_pair.second);
 
     _log_verbose("invoking premain");
-    ert_ego_premain(&_argc, &_argv, payload_data.c_str());
+    ert_ego_premain(&_argc, &_argv, &envc, &envp, payload_data.c_str());
     _log_verbose("premain done");
     ert_init_ttls(getenv("MARBLE_TTLS_CONFIG"));
 
@@ -134,15 +139,18 @@ ert_args_t ert_get_args()
     if (ert_get_args_ocall(&args) != OE_OK || args.envc < 0 || args.argc < 0)
         abort();
 
-    char** env = nullptr;
+    /* Don't make envp available as the environment yet, but rather store it as
+     a variable so the Go premain can access the host environment with the
+     supposed values (without actually setting them). This is a mitigation to
+     avoid the host messing with the Go premain with GODEBUG and similar.
+    */
     ert_copy_strings_from_host_to_enclave(
-        args.envp, &env, static_cast<size_t>(args.envc));
+        args.envp, &envp, static_cast<size_t>(args.envc));
 
-    assert(env);
+    assert(envp);
+    envc = args.envc;
 
     ert_args_t result{};
-    result.envc = args.envc;
-    result.envp = env;
 
     //
     // Get args from host.


### PR DESCRIPTION
### Proposed changes
- Pass the original host environment as a variable to Go, rather then actually setting it as the host environment. 
- This should avoid shenanigans such as the host setting GODEBUG and mess with the premain. While I do not believe that you can mess up execution with this that badly to actually skip the filtering without crashing the whole process, I think it's better to be safe than sorry.  

