### PR TITLE
add exception handler to support all cpuid leaves

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ endif()
 
 add_library(ego-enclave-lib
   src/enc.cpp
+  src/exception_handler.cpp
   src/go_runtime_cleanup.cpp)
 target_link_libraries(ego-enclave-lib PRIVATE openenclave::oe_includes)
 

--- a/ego/cmd/integration-test/main.go
+++ b/ego/cmd/integration-test/main.go
@@ -13,6 +13,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/klauspost/cpuid/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -27,6 +28,7 @@ func main() {
 	log.Println("Welcome to the enclave.")
 	testFileSystemMounts(assert, require)
 	testEnvVars(assert, require)
+	testCpuid(assert, require)
 }
 
 func testFileSystemMounts(assert *assert.Assertions, require *require.Assertions) {
@@ -94,4 +96,8 @@ func testEnvVars(assert *assert.Assertions, require *require.Assertions) {
 
 	// Check if other env vars were not taken over by using a common one to check against (here: LANG)
 	assert.Empty(os.Getenv("LANG"))
+}
+
+func testCpuid(assert *assert.Assertions, require *require.Assertions) {
+	assert.True(cpuid.CPU.Has(cpuid.CMOV))
 }

--- a/src/enc.cpp
+++ b/src/enc.cpp
@@ -16,6 +16,7 @@
 #include <stdexcept>
 #include <string_view>
 #include <thread>
+#include "exception_handler.h"
 #include "go_runtime_cleanup.h"
 
 static const auto _memfs_name = "edg_memfs";
@@ -155,6 +156,13 @@ int emain()
     _log_verbose("cleaning up the old goruntime: go_rc_unmap_memory");
     go_rc_unmap_memory();
     _log_verbose("cleaning up the old goruntime: done");
+
+    if (oe_add_vectored_exception_handler(false, ego_exception_handler) !=
+        OE_OK)
+    {
+        _log("oe_add_vectored_exception_handler failed");
+        return EXIT_FAILURE;
+    }
 
     // get payload entry point
     const auto base = static_cast<const uint8_t*>(ert::payload::get_base());

--- a/src/exception_handler.cpp
+++ b/src/exception_handler.cpp
@@ -1,0 +1,58 @@
+// Copyright (c) Edgeless Systems GmbH.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "exception_handler.h"
+
+extern "C" oe_result_t ert_cpuid_ocall(
+    unsigned int,
+    unsigned int,
+    unsigned int*,
+    unsigned int*,
+    unsigned int*,
+    unsigned int*);
+
+// This handler handles cpuid exceptions that aren't already handled by ERT/OE.
+//
+// Based on
+// https://github.com/deislabs/mystikos/blob/v0.7.0/tools/myst/enc/enc.c
+uint64_t ego_exception_handler(oe_exception_record_t* exception_context)
+{
+    auto& ctx = *exception_context->context;
+
+    // give up if this isn't a cpuid exception
+    const uint16_t cpuid_opcode = 0xA20F;
+    if (exception_context->code != OE_EXCEPTION_ILLEGAL_INSTRUCTION ||
+        *reinterpret_cast<uint16_t*>(ctx.rip) != cpuid_opcode)
+        return OE_EXCEPTION_CONTINUE_SEARCH;
+
+    const bool is_xsave_subleaf_zero = ctx.rax == 0xd && ctx.rcx == 0;
+
+    unsigned int eax = 0;
+    unsigned int ebx = 0;
+    unsigned int ecx = 0;
+    unsigned int edx = 0;
+    if (ert_cpuid_ocall(ctx.rax, ctx.rcx, &eax, &ebx, &ecx, &edx) != OE_OK)
+        return OE_EXCEPTION_CONTINUE_SEARCH;
+
+    if (is_xsave_subleaf_zero)
+    {
+        /* replace XSAVE/XRSTOR save area size with fixed large value of 4096,
+        to protect against spoofing attacks from untrusted host.
+        If host returns smaller xsave area than required, this can cause a
+        buffer overflow at context switch time.
+        We believe value of 4096 should be sufficient for forseeable future. */
+        if (ebx < 4096)
+            ebx = 4096;
+        if (ecx < 4096)
+            ecx = 4096;
+    }
+
+    ctx.rax = eax;
+    ctx.rbx = ebx;
+    ctx.rcx = ecx;
+    ctx.rdx = edx;
+    ctx.rip += sizeof cpuid_opcode;
+
+    return OE_EXCEPTION_CONTINUE_EXECUTION;
+}

--- a/src/exception_handler.h
+++ b/src/exception_handler.h
@@ -1,0 +1,3 @@
+#include <openenclave/enclave.h>
+
+uint64_t ego_exception_handler(oe_exception_record_t* exception_context);


### PR DESCRIPTION
cpuid inside SGX is an illegal instruction. ERT/OE catches it and handles selected leaves. This PR registers an exception handler to handle all the other leaves. This is the same way as mystikos solves it. Requires edgelesssys/edgelessrt#97