### PR TITLE
Fix/maxthreads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,18 @@ add_custom_command(
   OUTPUT test_private.pem
   COMMAND openssl genrsa -out test_private.pem -3 3072)
 
+# build concurrency-test with ertgo and sign it with oesign
+add_custom_command(
+  OUTPUT concurrency-test
+  DEPENDS ego-enclave test_private.pem ego/cmd/concurrency-test/enclave.conf ego/cmd/concurrency-test/main.go
+  COMMAND ${CMAKE_COMMAND} -E env GOROOT=${CMAKE_SOURCE_DIR}/_ertgo ${CMAKE_SOURCE_DIR}/_ertgo/bin/go build -o ${CMAKE_BINARY_DIR}
+  COMMAND oesign sign
+    -e ${CMAKE_BINARY_DIR}/ego-enclave
+    -c ${CMAKE_SOURCE_DIR}/ego/cmd/concurrency-test/enclave.conf
+    -k ${CMAKE_BINARY_DIR}/test_private.pem
+    --payload ${CMAKE_BINARY_DIR}/concurrency-test
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/ego/cmd/concurrency-test)
+
 # build the test marble with ertgo and sign it with oesign
 add_custom_command(
   OUTPUT test-marble
@@ -156,10 +168,11 @@ add_custom_command(
   COMMAND go build -o ${CMAKE_BINARY_DIR}
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/ego/cmd/marble-test)
 
-add_custom_target(marbletest ALL DEPENDS test-marble marble-test)
+add_custom_target(testexes ALL DEPENDS concurrency-test test-marble marble-test)
 
 enable_testing()
 add_test(NAME api-unit-tests COMMAND go test -race --count=3 ./... WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_test(NAME ego-unit-tests COMMAND go test -race --count=3 ./... WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/ego)
 add_test(integration ${CMAKE_SOURCE_DIR}/src/integration_test.sh)
+add_test(concurrency erthost ego-enclave:concurrency-test)
 add_test(marble marble-test)

--- a/ego/cmd/concurrency-test/enclave.conf
+++ b/ego/cmd/concurrency-test/enclave.conf
@@ -1,0 +1,6 @@
+Debug=1
+NumHeapPages=131072
+NumStackPages=1024
+NumTCS=9
+ProductID=1
+SecurityVersion=1

--- a/ego/cmd/concurrency-test/main.go
+++ b/ego/cmd/concurrency-test/main.go
@@ -1,0 +1,78 @@
+// Copyright (c) Edgeless Systems GmbH.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package main
+
+import (
+	"fmt"
+	"runtime"
+	"syscall"
+)
+
+// This tests the EGOMAXTHREADS feature for scheduling issues.
+
+func main() {
+	const (
+		numTCS     = 9            // sync with enclave.conf
+		maxProcs   = numTCS + 2   // greater than TCS so that it would cause OE_OUT_OF_THREADS with the unmodified Go scheduler
+		numWorkers = 3 * maxProcs // greater than maxProcs so that workers must be preempted
+	)
+
+	oldMaxProcs := runtime.GOMAXPROCS(maxProcs)
+	if !(2 <= oldMaxProcs && oldMaxProcs <= numTCS-4) { // EGo enforces default GOMAXPROCS to be in this range
+		panic(fmt.Sprintf("oldMaxProcs is %v", oldMaxProcs))
+	}
+
+	test(numWorkers)
+}
+
+func test(numWorkers int) {
+	// Create some Go routines that are connected by channels and pass values from the first to the last.
+	// If any of the Go routines wouldn't be scheduled anymore, the others couldn't make progress either.
+	c0 := make(chan int)
+	c1 := c0
+	for i := 0; i < numWorkers; i++ {
+		c2 := make(chan int)
+		go work(c1, c2)
+		c1 = c2
+	}
+
+	go produce(c0)
+	sum := 0
+	for x := range c1 {
+		sum += x
+	}
+	fmt.Println(sum)
+}
+
+func produce(ch chan int) {
+	const count = 10_000
+	sum := 0
+	for i := 0; i < count; i++ {
+		if i%(count/10) == 0 {
+			fmt.Printf("%v / %v\n", i, count)
+		}
+		sum += i
+		ch <- i
+	}
+	fmt.Println(sum)
+	close(ch)
+}
+
+func work(in, out chan int) {
+	var garbage []byte
+	for x := range in {
+		out <- x
+
+		// cgo call triggers specific scheduling logic
+		syscall.Nanosleep(&syscall.Timespec{Sec: 0, Nsec: 1_000}, nil)
+
+		// triggers GC from time to time
+		garbage = make([]byte, 1024)
+	}
+	_ = garbage
+	close(out)
+}

--- a/src/enc.cpp
+++ b/src/enc.cpp
@@ -83,7 +83,7 @@ static void _set_concurrency_limits()
     // not available for a Go proc.
 
     auto count = oe_get_num_tcs();
-    if (count < 10)
+    if (count < 6)
         return; // can only happen if enclave was manually signed instead of
                 // using `ego sign`
 
@@ -93,12 +93,7 @@ static void _set_concurrency_limits()
     // By default, GOMAXPROCS is the number of cores assigned to the process.
     // Thus, we only need to set it if number of cores come close to or are
     // above EGOMAXTHREADS.
-    //
-    // TODO We need a higher margin (was 2) between GOMAXPROCS and
-    // EGOMAXTHREADS, or else deadlocks can occur
-    // (https://github.com/edgelesssys/ego/issues/112). We should find the root
-    // cause and/or consider increasing NumTCS.
-    count -= 6;
+    count -= 2;
     if (thread::hardware_concurrency() > count)
         setenv("GOMAXPROCS", to_string(count).c_str(), false);
 }

--- a/src/load_test.sh
+++ b/src/load_test.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+set -e
+
+onexit()
+{
+  if [ $? -ne 0 ]; then
+    echo fail
+  else
+    echo pass
+  fi
+  pkill ego-host
+  rm -r "$tmp"
+}
+
+tmp=$(mktemp -d)
+trap onexit EXIT
+
+cd "$tmp"
+wget -qO- https://github.com/bojand/ghz/releases/download/v0.105.0/ghz-linux-x86_64.tar.gz | tar xz
+wget -qO- https://github.com/grpc/grpc-go/archive/refs/tags/v1.44.0.tar.gz | tar xz
+cd grpc-go-1.44.0/examples/helloworld
+
+ego-go build -o server ./greeter_server
+
+echo '{
+  "exe": "server",
+  "key": "private.pem",
+  "debug": true,
+  "heapSize": 512,
+  "env": [
+    { "name": "EGOMAXTHREADS", "value": "7" },
+    { "name": "GOMAXPROCS", "value": "9" }
+  ]
+}' > enclave.json
+
+ego sign
+
+# start grpc server
+ego run server &
+pid=$!
+sleep 10
+
+# start load test
+timeout 10m "$tmp/ghz" --insecure --proto helloworld/helloworld.proto --call helloworld.Greeter/SayHello -n900000 127.0.0.1:50051
+
+# check if process crashed
+kill -0 $pid


### PR DESCRIPTION
This fixes the EGOMAXTHREADS implementation and adds two tests. The load_test.sh requires an installed ego and I'll add it to the e2e test once this is merged.