### PR TITLE
AB#1789 add libsgx-enclave-common to install.json and refer to it on …

### DIFF
--- a/ego/cli/cli.go
+++ b/ego/cli/cli.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/spf13/afero"
@@ -96,6 +97,8 @@ func findCommonError(s string) error {
 		return ErrElfNoPie
 	case strings.Contains(s, "Failed to open Intel SGX device"):
 		return ErrSGXOpenFail
+	case regexp.MustCompile(`enclave_load_data failed \(addr=0x\w+, prot=0x1, err=0x1001\)`).MatchString(s):
+		return ErrLoadDataFailUnexpected
 	default:
 		return nil
 	}
@@ -135,3 +138,6 @@ var ErrElfNoPie = fmt.Errorf("%w: ELF image is not a PIE or shared object", ErrO
 // ErrSGXOpenFail is an Open Enclave error where OE failes to open the Intel SGX device.
 // This likely occures if a system does not support SGX or the required module is missing.
 var ErrSGXOpenFail = fmt.Errorf("%w: Failed to open Intel SGX device", ErrOEPlatform)
+
+// ErrLoadDataFailUnexpected is an Open Enclave error where enclave_load_data fails with error code 0x1001.
+var ErrLoadDataFailUnexpected = fmt.Errorf("%w: enclave_load_data failed: ENCLAVE_UNEXPECTED", ErrOEPlatform)

--- a/src/install.json
+++ b/src/install.json
@@ -4,12 +4,13 @@
 			"sgx-driver": "The SGX driver. Required on systems with a Linux kernel version prior to 5.11.",
 			"libsgx-launch": "SGX Launch package required for non-FLC SGX systems.",
 			"az-dcap-client": "The Microsoft Azure DCAP client. Required for remote attestation with an Azure VM.",
-			"libsgx-dcap-default-qpl": "SGX default DCAP Quote Provider Library. Required for remote attestation on non-Azure VMs."
+			"libsgx-dcap-default-qpl": "SGX default DCAP Quote Provider Library. Required for remote attestation on non-Azure VMs.",
+			"libsgx-enclave-common": "SGX base package. Required for some FLC systems."
 		},
 		"commands": {
 			"ubuntu-18.04-flc": {
 				"sgx-driver": [
-					"! test -e /dev/sgx && ! test -e /dev/isgx",
+					"! test -e /dev/sgx && ! test -e /dev/isgx && ! test -e /dev/sgx_enclave",
 					"wget https://download.01.org/intel-sgx/sgx-linux/2.12/distro/ubuntu18.04-server/sgx_linux_x64_driver_1.36.2.bin",
 					"echo '7b415b8a4367b3deb044ee7d94fffb7922df17a3da2a238da3f8db9391ecb650  sgx_linux_x64_driver_1.36.2.bin' | sha256sum -c",
 					"chmod +x sgx_linux_x64_driver_1.36.2.bin",
@@ -35,7 +36,7 @@
 			},
 			"ubuntu-18.04-nonflc": {
 				"sgx-driver": [
-					"! test -e /dev/sgx && ! test -e /dev/isgx",
+					"! test -e /dev/sgx && ! test -e /dev/isgx && ! test -e /dev/sgx_enclave",
 					"wget https://download.01.org/intel-sgx/sgx-linux/2.13.3/distro/ubuntu18.04-server/sgx_linux_x64_driver_2.11.0_2d2b795.bin",
 					"echo 'd8080eb99a7916ff957c3a187bb46c678e84c4948a671863ac573d4572dd374e  sgx_linux_x64_driver_2.11.0_2d2b795.bin' | sha256sum -c",
 					"chmod +x sgx_linux_x64_driver_2.11.0_2d2b795.bin",
@@ -51,7 +52,7 @@
 			},
 			"ubuntu-20.04-flc": {
 				"sgx-driver": [
-					"! test -e /dev/sgx && ! test -e /dev/isgx",
+					"! test -e /dev/sgx && ! test -e /dev/isgx && ! test -e /dev/sgx_enclave",
 					"wget https://download.01.org/intel-sgx/sgx-linux/2.12/distro/ubuntu20.04-server/sgx_linux_x64_driver_1.36.2.bin",
 					"echo 'e3e027b16dfe980859035a9437b198d21ca9d71825d2144756ac3eac759c489f sgx_linux_x64_driver_1.36.2.bin' | sha256sum -c",
 					"chmod +x sgx_linux_x64_driver_1.36.2.bin",
@@ -73,11 +74,18 @@
 					"apt install -y libsgx-dcap-default-qpl",
 					"ln -s /usr/lib/x86_64-linux-gnu/libdcap_quoteprov.so.1 /usr/lib/x86_64-linux-gnu/libdcap_quoteprov.so",
 					"sed -i 's/.*USE_SECURE_CERT=.*/USE_SECURE_CERT=FALSE/' /etc/sgx_default_qcnl.conf"
+				],
+				"libsgx-enclave-common": [
+					"wget -q https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key",
+					"echo '809cb39c4089843f923143834550b185f2e6aa91373a05c8ec44026532dab37c  intel-sgx-deb.key' | sha256sum -c",
+					"apt-key add intel-sgx-deb.key",
+					"add-apt-repository 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main'",
+					"apt install -y --no-install-recommends libsgx-enclave-common"
 				]
 			},
 			"ubuntu-20.04-nonflc": {
 				"sgx-driver": [
-					"! test -e /dev/sgx && ! test -e /dev/isgx",
+					"! test -e /dev/sgx && ! test -e /dev/isgx && ! test -e /dev/sgx_enclave",
 					"wget https://download.01.org/intel-sgx/sgx-linux/2.13.3/distro/ubuntu20.04-server/sgx_linux_x64_driver_2.11.0_2d2b795.bin",
 					"echo '8727e5441e6cccc3a77b72c747cc2eeda59ed20ef8502fa73d4865e50fc4d6fd  sgx_linux_x64_driver_2.11.0_2d2b795.bin' | sha256sum -c",
 					"chmod +x sgx_linux_x64_driver_2.11.0_2d2b795.bin",


### PR DESCRIPTION
…related errors

When installing the snap on a fresh machine, the following problems can be present:
* /dev/sgx symlinks are missing
* /dev isn't executable

Symlinks can be fixed by
* installing linux-base-sgx from Ubuntu packages
* installing libsgx-enclave-common from Intel packages
* creating udev rules manually
* creating symlinks manually (temporarily)

nonexecutable /dev can be fixed by
* installing libsgx-enclave-common from Intel packages
* remounting /dev (temporarily)
* adding a systemd service that remounts /dev on startup (this is what libsgx-enclave-common does) or maybe via fstab or some other autostart/automount mechanism

While I don't like that one needs to install an Intel package when using the snap, it still seems the easiest way to fix the errors.

On Azure, linux-base-sgx is preinstalled and /dev is executable. (I don't know why the latter is the case.) Thus, the snap runs out of the box.