### PR TITLE
AB#2173: Add feature to bundle a signed executable with the current EGo runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,16 @@ add_custom_command(
 add_custom_target(egobuild ALL DEPENDS ego)
 
 #
+# ego-bundle - the loader executable for bundled ego enclaves
+#
+add_custom_command(
+  OUTPUT ego-bundle
+  DEPENDS ${CMAKE_SOURCE_DIR}/ego/cmd/bundle/*.go ${CMAKE_SOURCE_DIR}/ego/internal/**/*.go
+  COMMAND ${CMAKE_SOURCE_DIR}/src/build_ego.sh ${CMAKE_BINARY_DIR}/ego-bundle ${PROJECT_VERSION} ${TRIMPATH}
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/ego/cmd/bundle)
+add_custom_target(egobundle ALL DEPENDS ego-bundle)
+
+#
 # install
 #
 
@@ -91,6 +101,7 @@ install(
   src/ego-go
   ${CMAKE_BINARY_DIR}/ego
   DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(FILES ${CMAKE_BINARY_DIR}/ego-bundle DESTINATION ${CMAKE_INSTALL_DATADIR})
 install(
   PROGRAMS ${OpenEnclave_DIR}/../../../bin/erthost
   RENAME ego-host

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ target_link_libraries(ego-enclave
 
 add_custom_command(
   OUTPUT ego
-  DEPENDS ego/cmd/ego/main.go ${CMAKE_SOURCE_DIR}/ego/cli/*.go ${CMAKE_SOURCE_DIR}/ego/config/*.go
+  DEPENDS ego/cmd/ego/main.go ${CMAKE_SOURCE_DIR}/ego/cli/*.go ${CMAKE_SOURCE_DIR}/ego/config/*.go ${CMAKE_SOURCE_DIR}/ego/internal/**/*.go
   COMMAND ${CMAKE_SOURCE_DIR}/src/build_ego.sh ${CMAKE_BINARY_DIR} ${PROJECT_VERSION} ${TRIMPATH}
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/ego/cmd/ego)
 add_custom_target(egobuild ALL DEPENDS ego)

--- a/ego/cli/bundle.go
+++ b/ego/cli/bundle.go
@@ -1,0 +1,245 @@
+// Copyright (c) Edgeless Systems GmbH.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package cli
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"debug/elf"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// ErrFileIsNotAnEGoBinary is returned when the file is not an enclave, therefore cannot possibly be bundled.
+var ErrFileIsNotAnEGoBinary = errors.New("file is not an EGo Binary")
+
+// ErrFileIsAlreadyBundled is returned when the file is already bundled. Technically, the outer binary is not an enclave either, but this is a more specific error.
+var ErrFileIsAlreadyBundled = errors.New("file is already bundled")
+
+// ErrFileHasNotBeenSignedYet is returned when the enclave has not been signed yet with 'ego sign', which would create a non-functional bundle.
+var ErrFileHasNotBeenSignedYet = errors.New("enclave has not been signed yet with 'ego sign'")
+
+// Bundle bundles an enclave with the currently installed EGo runtime into a single executable.
+func (c *Cli) Bundle(filename string, outputFilename string) (reterr error) {
+	// Check if the file is an enclave or already bundled
+	if err := c.checkIfBundable(filename); err != nil {
+		return err
+	}
+
+	// Build .tar.gz image containing the runtime and user enclave
+	tarFilename, err := c.buildImage(filename)
+	if err != nil {
+		return err
+	}
+	defer c.fs.Remove(tarFilename)
+
+	if outputFilename == "" {
+		outputFilename = filepath.Base(filename) + "-bundle"
+	}
+
+	// Prepare the bundle
+	if err := c.prepareBundle(filename, outputFilename); err != nil {
+		return err
+	}
+	defer func() {
+		if reterr != nil {
+			c.fs.Remove(outputFilename)
+		}
+	}()
+
+	// Add the runtime image to the bundle
+	if err := addSectionToELF(outputFilename, tarFilename, ".ego.bundle"); err != nil {
+		return err
+	}
+
+	fmt.Printf("Saved bundle as: %s\n", outputFilename)
+
+	return nil
+}
+
+// checkIfBundable checks if the file is an enclave or already bundled.
+func (c *Cli) checkIfBundable(filename string) error {
+	file, err := c.fs.Open(filename)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	// Open the ELF file and check if a section called ".oeinfo" exists
+	elf, err := elf.NewFile(file)
+	if err != nil {
+		return err
+	}
+
+	// Check if the ELF file has a section called ".oeinfo"
+	var isEnclave bool
+	var isAlreadyBundled bool
+	var isGoBinary bool
+	for _, section := range elf.Sections {
+		switch section.Name {
+		case ".oeinfo":
+			isEnclave = true
+		case ".ego.bundle":
+			isAlreadyBundled = true
+		case ".go.buildinfo":
+			isGoBinary = true
+		}
+	}
+
+	if isAlreadyBundled {
+		return ErrFileIsAlreadyBundled
+	}
+
+	if !isEnclave || !isGoBinary {
+		return ErrFileIsNotAnEGoBinary
+	}
+
+	// Check if the binary has been signed with `ego sign` yet by checking if the payload has been appended.
+	// We do not check here if it is actually valid. If it is not valid, the binary can still be bundled, but during launch the enclave will refuse to run.
+	payloadSize, _, _, err := getPayloadInformation(file)
+	if err != nil {
+		return err
+	}
+
+	if payloadSize == 0 {
+		return ErrFileHasNotBeenSignedYet
+	}
+
+	return nil
+}
+
+// buildImage builds a gzip-compressed tarball containing the EGo runtime.
+func (c *Cli) buildImage(enclaveFilename string) (tempFileName string, reterr error) {
+	// Create the tar file
+	tempFile, err := c.fs.TempFile("", "ego-runtime")
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		if reterr != nil {
+			c.fs.Remove(tempFile.Name())
+		}
+	}()
+	defer tempFile.Close()
+
+	// Setup tar writer with gzip compression
+	compressedWriter := gzip.NewWriter(tempFile)
+	defer compressedWriter.Close()
+	tarWriter := tar.NewWriter(compressedWriter)
+	defer tarWriter.Close()
+
+	// Add the runtime image to the tar file
+	if err := c.addToArchive(tarWriter, c.getEgoHostPath(), "ego-host"); err != nil {
+		return "", err
+	}
+	if err := c.addToArchive(tarWriter, c.getEgoEnclavePath(), "ego-enclave"); err != nil {
+		return "", err
+	}
+
+	// Add the enclave to the tar file
+	if err := c.addToArchive(tarWriter, enclaveFilename, "enclave"); err != nil {
+		return "", err
+	}
+
+	return tempFile.Name(), nil
+}
+
+// addToArchive adds a file from the filesystem to the tar archive.
+func (c *Cli) addToArchive(tw *tar.Writer, sourceFilename string, targetFilename string) error {
+	file, err := c.fs.Open(sourceFilename)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	sourceFileInfo, err := file.Stat()
+	if err != nil {
+		return err
+	}
+
+	header, err := tar.FileInfoHeader(sourceFileInfo, sourceFileInfo.Name())
+	if err != nil {
+		return err
+	}
+
+	header.Name = targetFilename
+
+	if err := tw.WriteHeader(header); err != nil {
+		return err
+	}
+
+	n, err := io.Copy(tw, file)
+	if err != nil {
+		return err
+	}
+
+	if n != sourceFileInfo.Size() {
+		return fmt.Errorf("file size mismatch: %d written instead of expected %d bytes", n, sourceFileInfo.Size())
+	}
+
+	return nil
+}
+
+// prepareBundle copies the "empty" bundle executable to the target location and names it after the enclave to be bundled.
+func (c *Cli) prepareBundle(inputFilename string, outputFilename string) (reterr error) {
+	// Copy the base bundle loader binary into the new file
+	loaderBinary, err := c.fs.Open(c.getEgoBundlePath())
+	if err != nil {
+		return err
+	}
+	defer loaderBinary.Close()
+
+	loaderBinaryInfo, err := loaderBinary.Stat()
+	if err != nil {
+		return err
+	}
+
+	// Create target bundled file. Apparently, 'go build' creates binaries with 775... So let's just replicate this.
+	binaryToPack, err := c.fs.OpenFile(outputFilename, os.O_CREATE|os.O_RDWR, 0o775)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if reterr != nil {
+			c.fs.Remove(binaryToPack.Name())
+		}
+	}()
+	defer binaryToPack.Close()
+
+	n, err := io.Copy(binaryToPack, loaderBinary)
+	if err != nil {
+		return err
+	}
+	if n != loaderBinaryInfo.Size() {
+		return fmt.Errorf("file size mismatch: %d written instead of expected %d bytes", n, loaderBinaryInfo.Size())
+	}
+
+	return nil
+}
+
+func (c *Cli) getEgoBundlePath() string {
+	return filepath.Join(c.egoPath, "share", "ego-bundle")
+}
+
+// addSectionToELF calls objcopy (part of binutils) to add a local binary file as a section to an ELF file.
+func addSectionToELF(targetFilename string, dataFilename string, sectionName string) error {
+	// Use objcopy to copy the data file into the target ELF file
+	cmd := exec.Command("objcopy", "--add-section", sectionName+"="+dataFilename, targetFilename, targetFilename)
+	if err := cmd.Run(); err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			fmt.Println(string(exitError.Stderr))
+			return fmt.Errorf("objcopy exited with error: %d", exitError.ExitCode())
+		}
+		return err
+	}
+
+	return nil
+}

--- a/ego/cli/bundle_test.go
+++ b/ego/cli/bundle_test.go
@@ -1,0 +1,231 @@
+// Copyright (c) Edgeless Systems GmbH.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package cli
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"debug/elf"
+	"encoding/json"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"ego/config"
+	"ego/internal/launch"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckIfBundable(t *testing.T) {
+	/*
+		Does not test the following cases:
+		- OpenEnclave binary, but not an EGo enclave
+		- already-bundled EGo binary
+	*/
+	const exe = "to-be-signed-enclave"
+
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// Setup a fake filesystem and fake signer.
+	fs := afero.Afero{Fs: afero.NewMemMapFs()}
+	runner := signRunner{fs: fs}
+	cli := NewCli(&runner, fs)
+
+	// First, check a no enclave binary. Let's use ourselves as a test here, so we do not have any special dependencies.
+	testNonEnclaveBinaryPath, err := os.Executable()
+	require.NoError(err)
+	testNonEnclaveBinary, err := os.ReadFile(testNonEnclaveBinaryPath)
+	require.NoError(err)
+
+	require.NoError(fs.WriteFile("no-enclave", testNonEnclaveBinary, 0o644))
+	assert.ErrorIs(cli.checkIfBundable("no-enclave"), ErrFileIsNotAnEGoBinary)
+
+	// Now, let's check an unsigned binary
+	require.NoError(fs.WriteFile(exe, elfUnsigned, 0o644))
+	assert.ErrorIs(cli.checkIfBundable(exe), ErrFileHasNotBeenSignedYet)
+
+	// Let's fake-sign the binary by just embedding the enclave configuration.
+	testConf := &config.Config{
+		Exe:             exe,
+		Key:             defaultPrivKeyFilename,
+		Debug:           true,
+		HeapSize:        512, //[MB]
+		ProductID:       1,
+		SecurityVersion: 1,
+	}
+	jsonData, err := json.Marshal(testConf)
+	require.NoError(err)
+	err = cli.embedConfigAsPayload(exe, jsonData)
+	assert.NoError(err)
+
+	// Now, check if our enclave passes as bundable
+	assert.NoError(cli.checkIfBundable(exe))
+}
+
+func TestAddToArchive(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// Setup a fake filesystem
+	fs := afero.Afero{Fs: afero.NewMemMapFs()}
+	cli := NewCli(nil, fs)
+	require.NoError(fs.MkdirAll("/this/is/a/directory/test", 0o777))
+	require.NoError(fs.WriteFile("/this/is/a/directory/test/test.txt", []byte("test"), 0o644))
+	require.NoError(fs.WriteFile("/rootfile.txt", []byte("test"), 0o644))
+	tmpTarFile, err := fs.TempFile("", "")
+	require.NoError(err)
+
+	// Setup tar writer with gzip compression
+	compressedWriter := gzip.NewWriter(tmpTarFile)
+	defer compressedWriter.Close()
+	tarWriter := tar.NewWriter(compressedWriter)
+	defer tarWriter.Close()
+
+	// Add files to archive
+	assert.NoError(cli.addToArchive(tarWriter, "/this/is/a/directory/test/test.txt", "another/directory/test.txt"))
+	assert.NoError(cli.addToArchive(tarWriter, "/rootfile.txt", "unpacked-rootfile.txt"))
+	tarWriter.Close()
+	compressedWriter.Close()
+
+	// Try to untar the archive
+	tarFile, err := fs.Open(tmpTarFile.Name())
+	require.NoError(err)
+	assert.NoError(launch.UntarGzip(fs, tarFile, "/unpacked"))
+
+	// Check if the files are there
+	unpackedRootFileContent, err := fs.ReadFile("/unpacked/unpacked-rootfile.txt")
+	assert.NoError(err)
+	assert.Equal([]byte("test"), unpackedRootFileContent)
+	unpackedDirectoryFileContent, err := fs.ReadFile("/unpacked/another/directory/test.txt")
+	assert.NoError(err)
+	assert.Equal([]byte("test"), unpackedDirectoryFileContent)
+}
+
+func TestBuildImage(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// Setup a fake filesystem
+	fs := afero.Afero{Fs: afero.NewMemMapFs()}
+	cli := NewCli(nil, fs)
+
+	fakeContentEgoHost := []byte("this-is-no-real-elf: ego-host")
+	fakeContentEgoEnclave := []byte("this-is-no-real-elf: ego-enclave")
+	fakeContentMyEnclave := []byte("this-is-no-real-elf: my-enclave")
+
+	binPath := filepath.Join(cli.egoPath, "bin")
+	sharePath := filepath.Join(cli.egoPath, "share")
+	require.NoError(fs.MkdirAll(binPath, 0o777))
+	require.NoError(fs.MkdirAll(sharePath, 0o777))
+	require.NoError(fs.WriteFile(filepath.Join(binPath, "ego-host"), fakeContentEgoHost, 0o644))
+	require.NoError(fs.WriteFile(filepath.Join(sharePath, "ego-enclave"), fakeContentEgoEnclave, 0o644))
+	require.NoError(fs.WriteFile("my-enclave", fakeContentMyEnclave, 0o644))
+
+	// Run the prepare bundle command
+	pathToBundle, err := cli.buildImage("my-enclave")
+	assert.NoError(err)
+
+	bundleFile, err := fs.Open(pathToBundle)
+	require.NoError(err)
+
+	/*
+		Untar the archive. The structure should be the following:
+		- bin/ego-host
+		- share/ego-enclave
+		- my-enclave
+	*/
+	require.NoError(launch.UntarGzip(fs, bundleFile, "/unpacked"))
+	unpackedBinFileContent, err := fs.ReadFile("/unpacked/ego-host")
+	assert.NoError(err)
+	assert.Equal(fakeContentEgoHost, unpackedBinFileContent)
+	unpackedShareFileContent, err := fs.ReadFile("/unpacked/ego-enclave")
+	assert.NoError(err)
+	assert.Equal(fakeContentEgoEnclave, unpackedShareFileContent)
+	unpackedEnclaveFileContent, err := fs.ReadFile("/unpacked/enclave")
+	assert.NoError(err)
+	assert.Equal(fakeContentMyEnclave, unpackedEnclaveFileContent)
+}
+
+func TestPrepareBundle(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// Setup a fake filesystem
+	fs := afero.Afero{Fs: afero.NewMemMapFs()}
+	cli := NewCli(nil, fs)
+
+	fakeContentEgoBundle := []byte("this-is-no-real-elf: ego-bundle")
+	sharePath := filepath.Join(cli.egoPath, "share")
+	require.NoError(fs.MkdirAll(sharePath, 0o777))
+	require.NoError(fs.WriteFile(filepath.Join(sharePath, "ego-bundle"), fakeContentEgoBundle, 0o644))
+	file, err := fs.Create("my-enclave")
+	require.NoError(err)
+	defer file.Close()
+
+	// Run the prepare bundle command
+	assert.NoError(cli.prepareBundle(file.Name(), "created-bundle"))
+
+	// Check if the bundle has been copied to the right place
+	bundleContent, err := fs.ReadFile("created-bundle")
+	assert.NoError(err)
+	assert.Equal(fakeContentEgoBundle, bundleContent)
+}
+
+func TestAddSectionToELF(t *testing.T) {
+	// This test stores files on the real filesystem, as we cannot get away with mocking here due to the external call to objdump which requires a real file...
+	// If objdump does not exist on the current running system, we skip this step.
+	objdumpPath, err := exec.LookPath("objdump")
+	if err != nil || objdumpPath == "" {
+		t.Skip("objdump not found, cannot run this test.")
+	}
+
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// Create two test files, with the second one to be embedded into the first one
+	testElfFile, err := os.CreateTemp("", "ego-unittest")
+	require.NoError(err)
+	defer testElfFile.Close()
+	defer os.Remove(testElfFile.Name())
+	testContentFile, err := os.CreateTemp("", "ego-unittest")
+	require.NoError(err)
+	defer testElfFile.Close()
+	defer os.Remove(testElfFile.Name())
+
+	// Write the elf file which is supposed to get the section added
+	n, err := io.Copy(testElfFile, bytes.NewReader(elfUnsigned))
+	require.NoError(err)
+	require.EqualValues(len(elfUnsigned), n)
+
+	// Write the content of the section to be added
+	testContent := []byte("this is a test")
+	n, err = io.Copy(testContentFile, bytes.NewReader(testContent))
+	require.NoError(err)
+	require.EqualValues(len(testContent), n)
+
+	// Embed the content of the content file into the elf file
+	assert.NoError(addSectionToELF(testElfFile.Name(), testContentFile.Name(), ".ego.bundle"))
+
+	// Check if the section has been added to the elf file
+	elf, err := elf.Open(testElfFile.Name())
+	require.NoError(err)
+	defer elf.Close()
+	elfSection := elf.Section(".ego.bundle")
+	require.NotNil(elfSection)
+
+	// Check if the section has the correct content
+	sectionContent, err := elfSection.Data()
+	assert.NoError(err)
+	assert.Equal(testContent, sectionContent)
+}

--- a/ego/cli/cli.go
+++ b/ego/cli/cli.go
@@ -7,35 +7,23 @@
 package cli
 
 import (
-	"errors"
-	"fmt"
-	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"regexp"
-	"strings"
+
+	"ego/internal/launch"
 
 	"github.com/spf13/afero"
 )
 
-// Runner runs Cmd objects.
-type Runner interface {
-	Run(cmd *exec.Cmd) error
-	Output(cmd *exec.Cmd) ([]byte, error)
-	CombinedOutput(cmd *exec.Cmd) ([]byte, error)
-	ExitCode(cmd *exec.Cmd) int
-}
-
 // Cli implements the ego commands.
 type Cli struct {
-	runner  Runner
+	runner  launch.Runner
 	fs      afero.Afero
 	egoPath string
 }
 
 // NewCli creates a new Cli object.
-func NewCli(runner Runner, fs afero.Fs) *Cli {
+func NewCli(runner launch.Runner, fs afero.Fs) *Cli {
 	exe, err := os.Executable()
 	if err != nil {
 		panic(err)
@@ -47,97 +35,6 @@ func NewCli(runner Runner, fs afero.Fs) *Cli {
 	}
 }
 
-func (c *Cli) run(cmd *exec.Cmd) (int, error) {
-	// force line buffering for stdout
-	// otherwise it will be fully buffered because our stdout is not a tty
-	path, err := exec.LookPath("stdbuf")
-	if err != nil {
-		return 1, err
-	}
-	cmd.Path = path
-	cmd.Args = append([]string{"stdbuf", "-oL"}, cmd.Args...)
-
-	cmd.Stdin = os.Stdin
-
-	// capture stdout and stderr
-	var stdout, stderr cappedBuffer
-	cmd.Stdout = io.MultiWriter(os.Stdout, &stdout)
-	cmd.Stderr = io.MultiWriter(os.Stderr, &stderr)
-
-	if err := c.runner.Run(cmd); err != nil {
-		if _, ok := err.(*exec.ExitError); !ok {
-			return 1, err
-		}
-	}
-	return c.runner.ExitCode(cmd), findCommonError(string(stdout) + string(stderr))
-}
-
 func (c *Cli) getOesignPath() string {
 	return filepath.Join(c.egoPath, "bin", "ego-oesign")
 }
-
-type cappedBuffer []byte
-
-func (b *cappedBuffer) Write(p []byte) (int, error) {
-	if len(*b) < 1000 {
-		*b = append(*b, p...)
-	}
-	return len(p), nil
-}
-
-func findCommonError(s string) error {
-	switch {
-	case strings.Contains(s, "enclave_initialize failed (err=0x5)"):
-		return ErrEnclIniFailInvalidMeasurement
-	case strings.Contains(s, "enclave_initialize failed (err=0x1001)"):
-		return ErrEnclIniFailUnexpected
-	case strings.Contains(s, "oe_sgx_is_valid_attributes failed: attributes = 0"):
-		return ErrValidAttr0
-	case strings.Contains(s, "ELF image is not a PIE or shared object"):
-		return ErrElfNoPie
-	case strings.Contains(s, "Failed to open Intel SGX device"):
-		return ErrSGXOpenFail
-	case regexp.MustCompile(`enclave_load_data failed \(addr=0x\w+, prot=0x1, err=0x1001\)`).MatchString(s):
-		return ErrLoadDataFailUnexpected
-	default:
-		return nil
-	}
-}
-
-// ErrOEInvalidImg is a representation of Open Enclaves OE_INVALID_IMAGE return code.
-var ErrOEInvalidImg = errors.New("OE_INVALID_IMAGE")
-
-// ErrOEFailure is a representation of Open Enclaves OE_FAILURE return code.
-var ErrOEFailure = errors.New("OE_FAILURE")
-
-// ErrOEPlatform is a representation of Open Enclaves OE_PLATFORM_ERROR return code.
-var ErrOEPlatform = errors.New("OE_PLATFORM_ERROR")
-
-// ErrOECrypto is a representation of Open Enclaves OE_CRYPTO_ERROR return code.
-var ErrOECrypto = errors.New("OE_CRYPTO_ERROR")
-
-// ErrExtUnknown is a unknown error from an external tool.
-var ErrExtUnknown = errors.New("unknown external error")
-
-// ErrEnclIniFailInvalidMeasurement is an Open Enclave error where enclave_initialize fails with error code 0x5.
-// This likely occurs if the signature of the binary is invalid and the binary needs to be resigned.
-var ErrEnclIniFailInvalidMeasurement = fmt.Errorf("%w: enclave_initialize failed: ENCLAVE_INVALID_MEASUREMENT", ErrOEPlatform)
-
-// ErrEnclIniFailUnexpected is an Open Enclave error where enclave_initialize fails with error code 0x1001.
-// On non-FLC systems this occurs if the libsgx-launch package is not installed.
-var ErrEnclIniFailUnexpected = fmt.Errorf("%w: enclave_initialize failed: ENCLAVE_UNEXPECTED", ErrOEPlatform)
-
-// ErrValidAttr0 is an Open Enclave error where oe_sgx_is_valid_attributes fails.
-// This likely occures if an unsigned binary is run.
-var ErrValidAttr0 = fmt.Errorf("%w: oe_sgx_is_valid_attributes failed: attributes = 0", ErrOEFailure)
-
-// ErrElfNoPie is an Open Enclave error where the ELF image is not a PIE or shared object.
-// This likely occures if a binary is run which was not built with ego-go.
-var ErrElfNoPie = fmt.Errorf("%w: ELF image is not a PIE or shared object", ErrOEInvalidImg)
-
-// ErrSGXOpenFail is an Open Enclave error where OE failes to open the Intel SGX device.
-// This likely occures if a system does not support SGX or the required module is missing.
-var ErrSGXOpenFail = fmt.Errorf("%w: Failed to open Intel SGX device", ErrOEPlatform)
-
-// ErrLoadDataFailUnexpected is an Open Enclave error where enclave_load_data fails with error code 0x1001.
-var ErrLoadDataFailUnexpected = fmt.Errorf("%w: enclave_load_data failed: ENCLAVE_UNEXPECTED", ErrOEPlatform)

--- a/ego/cli/run.go
+++ b/ego/cli/run.go
@@ -7,28 +7,25 @@
 package cli
 
 import (
-	"os"
-	"os/exec"
 	"path/filepath"
+
+	"ego/internal/launch"
 )
 
 // Run runs a signed executable in standalone mode.
 func (c *Cli) Run(filename string, args []string) (int, error) {
-	enclaves := filepath.Join(c.egoPath, "share", "ego-enclave") + ":" + filename
-	args = append([]string{enclaves}, args...)
-	os.Setenv("EDG_EGO_PREMAIN", "0")
-	cmd := exec.Command(c.getEgoHostPath(), args...)
-	return c.run(cmd)
+	return launch.RunEnclave(filename, args, c.getEgoHostPath(), c.getEgoEnclavePath(), c.runner)
 }
 
 // Marblerun runs a signed executable as a Marblerun Marble.
 func (c *Cli) Marblerun(filename string) (int, error) {
-	enclaves := filepath.Join(c.egoPath, "share", "ego-enclave") + ":" + filename
-	os.Setenv("EDG_EGO_PREMAIN", "1")
-	cmd := exec.Command(c.getEgoHostPath(), enclaves)
-	return c.run(cmd)
+	return launch.RunEnclaveMarblerun(filename, c.getEgoHostPath(), c.getEgoEnclavePath(), c.runner)
 }
 
 func (c *Cli) getEgoHostPath() string {
 	return filepath.Join(c.egoPath, "bin", "ego-host")
+}
+
+func (c *Cli) getEgoEnclavePath() string {
+	return filepath.Join(c.egoPath, "share", "ego-enclave")
 }

--- a/ego/cli/signerid.go
+++ b/ego/cli/signerid.go
@@ -14,6 +14,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"ego/internal/launch"
 )
 
 type eradump struct {
@@ -36,8 +38,8 @@ func (c *Cli) signeridByKey(path string) (string, error) {
 			return "", errors.New(string(err.Stderr))
 		}
 		fmt.Fprintln(os.Stderr, out)
-		if strings.Contains(out, ErrOECrypto.Error()) {
-			return "", ErrOECrypto
+		if strings.Contains(out, launch.ErrOECrypto.Error()) {
+			return "", launch.ErrOECrypto
 		}
 	}
 
@@ -46,7 +48,6 @@ func (c *Cli) signeridByKey(path string) (string, error) {
 
 func (c *Cli) readEradumpJSONtoStruct(path string) (*eradump, error) {
 	data, err := c.runner.Output(exec.Command(c.getOesignPath(), "eradump", "-e", path))
-
 	if err != nil {
 		if err, ok := err.(*exec.ExitError); ok {
 			return nil, errors.New(string(err.Stderr))

--- a/ego/cmd/bundle/main.go
+++ b/ego/cmd/bundle/main.go
@@ -1,0 +1,117 @@
+// Copyright (c) Edgeless Systems GmbH.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//go:build linux
+// +build linux
+
+package main
+
+import (
+	"debug/elf"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+
+	"ego/internal/launch"
+
+	"github.com/spf13/afero"
+)
+
+// Don't touch! Automatically injected at build-time.
+var (
+	version   = "0.0.0"
+	gitCommit = "0000000000000000000000000000000000000000"
+)
+
+// ErrExecutableDoesNotContainBundle is triggered when this executable is launched without containing a bundled enclave image as the ".ego.bundle" section.
+var ErrExecutableDoesNotContainBundle = errors.New("executable does not contain an enclave bundle")
+
+func main() {
+	fmt.Fprintf(os.Stderr, "EGo (bundled) v%v (%v)\n", version, gitCommit)
+
+	// Open the current execeutable
+	execPath, err := os.Executable()
+	if err != nil {
+		panic(err)
+	}
+
+	// Parse ourselves as an ELF file so we get access to ELF sections later
+	elfFile, err := elf.Open(execPath)
+	if err != nil {
+		panic(err)
+	}
+	defer elfFile.Close()
+
+	// Use the "host" environment and not a mocked one for unit tests
+	fs := afero.NewOsFs()
+	runner := launch.OsRunner{}
+
+	// Run the unpacking & launch the unpacked enclave.
+	// Take the error from the enclave as the exit code, unless we failed to execute the enclave before.
+	exitCode, err := run(fs, elfFile, runner)
+	if err != nil {
+		panic(err)
+	}
+	os.Exit(exitCode)
+}
+
+func run(fs afero.Fs, selfElfFile *elf.File, runner launch.Runner) (int, error) {
+	// Create a temporary directory for both runtime and enclave
+	tempEGoRootPath, err := afero.TempDir(fs, "", "ego-bundle")
+	if err != nil {
+		return 1, err
+	}
+	defer fs.RemoveAll(tempEGoRootPath)
+
+	// Register cleanup handler to clean-up on STRG+C
+	cleanupHandler(tempEGoRootPath)
+
+	// Unpack the runtime and enclave
+	if err := unpackBundledImage(fs, tempEGoRootPath, selfElfFile); err != nil {
+		return 1, err
+	}
+
+	enclaveFilename, egoHostFilename, egoEnclaveFilename := createPathsForLaunch(tempEGoRootPath)
+
+	// Run the enclave
+	exitCode, err := launch.RunEnclave(enclaveFilename, os.Args[1:], egoHostFilename, egoEnclaveFilename, runner)
+	if err != nil {
+		return 1, err
+	}
+
+	return exitCode, nil
+}
+
+func createPathsForLaunch(tempEGoRootPath string) (enclaveFilename string, egoHostFilename string, egoEnclaveFilename string) {
+	enclaveFilename = filepath.Join(tempEGoRootPath, "enclave")
+	egoHostFilename = filepath.Join(tempEGoRootPath, "ego-host")
+	egoEnclaveFilename = filepath.Join(tempEGoRootPath, "ego-enclave")
+	return
+}
+
+// unpackBundledImage decompresses the runtime and unpacks it to the temporary directory.
+func unpackBundledImage(fs afero.Fs, path string, elfFile *elf.File) error {
+	// Read the runtime section
+	runtimeSection := elfFile.Section(".ego.bundle")
+	if runtimeSection == nil {
+		return ErrExecutableDoesNotContainBundle
+	}
+
+	return launch.UntarGzip(fs, runtimeSection.Open(), path)
+}
+
+// cleanupHandler removes the temp directory when the exit of the process is requested, since the defered functions will not run otherwise.
+func cleanupHandler(egoTempPath string) {
+	c := make(chan os.Signal, 2)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-c
+		os.RemoveAll(egoTempPath)
+	}()
+}

--- a/ego/cmd/bundle/main_test.go
+++ b/ego/cmd/bundle/main_test.go
@@ -1,0 +1,305 @@
+// Copyright (c) Edgeless Systems GmbH.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package main
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"debug/elf"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// create an unsigned EGo executable
+var elfUnsigned = func() []byte {
+	const outFile = "hello"
+	const srcFile = outFile + ".go"
+
+	goroot, err := filepath.Abs(filepath.Join("..", "..", "..", "_ertgo"))
+	if err != nil {
+		panic(err)
+	}
+
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(dir)
+
+	// write minimal source file
+	const src = `package main;import _"time";func main(){}`
+	if err := os.WriteFile(filepath.Join(dir, srcFile), []byte(src), 0o400); err != nil {
+		panic(err)
+	}
+
+	// compile
+	cmd := exec.Command(filepath.Join(goroot, "bin", "go"), "build", srcFile)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GOROOT="+goroot)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		panic(err)
+	}
+
+	// read resulting executable
+	data, err := os.ReadFile(filepath.Join(dir, outFile))
+	if err != nil {
+		panic(err)
+	}
+
+	return data
+}()
+
+func setupTest(t *testing.T) (string, error) {
+	// Setup a fake filesystem to create a tar file
+	fs := afero.NewMemMapFs()
+	memfsTarFile, err := fs.Create("test-tar-file")
+	if err != nil {
+		return "", err
+	}
+
+	// Create a fake tar file
+	gw := gzip.NewWriter(memfsTarFile)
+	defer gw.Close()
+	tw := tar.NewWriter(gw)
+	defer tw.Close()
+	if err := addStubFileToArchive(tw, fs, "bin/ego-host"); err != nil {
+		return "", err
+	}
+	if err := addStubFileToArchive(tw, fs, "share/ego-enclave"); err != nil {
+		return "", err
+	}
+	if err := addStubFileToArchive(tw, fs, "enclave"); err != nil {
+		return "", err
+	}
+	if err := tw.Close(); err != nil {
+		return "", err
+	}
+	if err := gw.Close(); err != nil {
+		return "", err
+	}
+
+	// Get file size
+	memFsTarFileStat, err := memfsTarFile.Stat()
+	if err != nil {
+		return "", err
+	}
+
+	// Reset file offset to so we can copy the file
+	_, err = memfsTarFile.Seek(0, 0)
+	if err != nil {
+		return "", err
+	}
+
+	// Copy the tar file to the host
+	osTarFile, err := os.CreateTemp("", "ego-unittest")
+	if err != nil {
+		return "", err
+	}
+	defer osTarFile.Close()
+	defer os.Remove(osTarFile.Name())
+
+	n, err := io.Copy(osTarFile, memfsTarFile)
+	if err != nil {
+		return osTarFile.Name(), err
+	} else if n != memFsTarFileStat.Size() {
+		return osTarFile.Name(), fmt.Errorf("copied %d bytes, expected %d", n, memFsTarFileStat.Size())
+	}
+
+	// Copy our silently compiled test-binary, which is not the real bundle executable, to the host file system
+	osBinaryFile, err := os.CreateTemp("", "ego-unittest")
+	if err != nil {
+		return osTarFile.Name(), err
+	}
+	defer osBinaryFile.Close()
+
+	n, err = io.Copy(osBinaryFile, bytes.NewReader(elfUnsigned))
+	if err != nil {
+		return osBinaryFile.Name(), err
+	} else if n != int64(len(elfUnsigned)) {
+		return osBinaryFile.Name(), fmt.Errorf("copied %d bytes, expected %d", n, len(elfUnsigned))
+	}
+
+	// Embed the tar file into the elf file
+	if err := addSectionToELF(osBinaryFile.Name(), osTarFile.Name(), ".ego.bundle"); err != nil {
+		return osBinaryFile.Name(), err
+	}
+
+	return osBinaryFile.Name(), nil
+}
+
+func TestUnpackBundledImage(t *testing.T) {
+	objdumpPath, err := exec.LookPath("objdump")
+	if err != nil || objdumpPath == "" {
+		t.Skip("objdump not found, cannot run this test.")
+	}
+
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// Create test files
+	elfFilePath, err := setupTest(t)
+	if elfFilePath != "" {
+		defer os.Remove(elfFilePath)
+	}
+	require.NoError(err)
+
+	// Load the ELF file
+	elfFile, err := elf.Open(elfFilePath)
+	require.NoError(err)
+	defer elfFile.Close()
+
+	// Run the unpacker
+	fs := afero.NewMemMapFs()
+	unpackingPath, err := afero.TempDir(fs, "", "ego-unittest")
+	require.NoError(err)
+	defer fs.RemoveAll(unpackingPath)
+
+	assert.NoError(unpackBundledImage(fs, unpackingPath, elfFile))
+
+	// Check that the tar file was unpacked
+	egoHostFile, err := afero.ReadFile(fs, filepath.Join(unpackingPath, "bin/ego-host"))
+	assert.NoError(err)
+	assert.Equal(string(egoHostFile), "this is a test")
+	egoEnclaveFile, err := afero.ReadFile(fs, filepath.Join(unpackingPath, "share/ego-enclave"))
+	assert.NoError(err)
+	assert.Equal(string(egoEnclaveFile), "this is a test")
+	enclaveFile, err := afero.ReadFile(fs, filepath.Join(unpackingPath, "enclave"))
+	assert.NoError(err)
+	assert.Equal(string(enclaveFile), "this is a test")
+}
+
+func TestRun(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// Create test files
+	elfFilePath, err := setupTest(t)
+	if elfFilePath != "" {
+		defer os.Remove(elfFilePath)
+	}
+	require.NoError(err)
+
+	// Load the ELF file
+	elfFile, err := elf.Open(elfFilePath)
+	require.NoError(err)
+	defer elfFile.Close()
+
+	// Prepare test environment
+	fs := afero.NewMemMapFs()
+	runner := &testRunner{}
+	os.Args = []string{"fake-argv0"}
+
+	// Test to run the main part of the code.
+	exitCode, err := run(fs, elfFile, runner)
+	assert.NoError(err)
+	assert.Equal(42, exitCode) // That's just here to check that this should be the error code returned by the test runner and not by another error inside error.
+
+	/*
+		A valid run looks something like this: [/usr/bin/stdbuf -oL /tmp/ego-bundle905847970/bin/ego-host /tmp/ego-bundle905847970/share/ego-enclave:/tmp/ego-bundle905847970/enclave]
+		Given that the temp directory is created and deleted inside run, the files are already gone when we exit.
+		Therefore, we just check if the paths looks reasonable.
+		Correct unpacking should be tested by TestUnpackBundledImage otherwise.
+		Also, this uses a weird syntax given that runner.run is a []*exec.Cmd.
+		This means we want to take a look at the first run [0], and then check if the thrird [2] and fourth argument [3] contain something like the valid output mentioned above.
+	*/
+	assert.Contains(runner.run[0].Args[2], "/ego-host")
+	assert.Contains(runner.run[0].Args[3], "/ego-enclave:")
+	assert.Contains(runner.run[0].Args[3], "/enclave")
+}
+
+func addStubFileToArchive(tw *tar.Writer, fs afero.Fs, targetFilename string) error {
+	path := filepath.Dir(targetFilename)
+	if err := fs.MkdirAll(path, 0o755); err != nil {
+		return err
+	}
+
+	if err := afero.WriteFile(fs, targetFilename, []byte("this is a test"), 0o755); err != nil {
+		return err
+	}
+
+	file, err := fs.Open(targetFilename)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	sourceFileInfo, err := file.Stat()
+	if err != nil {
+		return err
+	}
+
+	header, err := tar.FileInfoHeader(sourceFileInfo, sourceFileInfo.Name())
+	if err != nil {
+		return err
+	}
+
+	header.Name = targetFilename
+
+	if err := tw.WriteHeader(header); err != nil {
+		return err
+	}
+
+	n, err := io.Copy(tw, file)
+	if err != nil {
+		return err
+	}
+
+	if n != sourceFileInfo.Size() {
+		return fmt.Errorf("file size mismatch: %d written instead of expected %d bytes", n, sourceFileInfo.Size())
+	}
+
+	return nil
+}
+
+// addSectionToELF calls objcopy (part of binutils) to add a local binary file as a section to an ELF file.
+func addSectionToELF(targetFilename string, dataFilename string, sectionName string) error {
+	// Use objcopy to copy the data file into the target ELF file
+	cmd := exec.Command("objcopy", "--add-section", sectionName+"="+dataFilename, targetFilename, targetFilename)
+	if err := cmd.Run(); err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			fmt.Println(string(exitError.Stderr))
+			return fmt.Errorf("objcopy exited with error: %d", exitError.ExitCode())
+		}
+		return err
+	}
+
+	return nil
+}
+
+// Lifted from cli/runner_test.go
+type testRunner struct {
+	run []*exec.Cmd
+}
+
+func (r *testRunner) Run(cmd *exec.Cmd) error {
+	r.run = append(r.run, cmd)
+	return nil
+}
+
+func (*testRunner) Output(cmd *exec.Cmd) ([]byte, error) {
+	panic(cmd.Path)
+}
+
+func (*testRunner) CombinedOutput(cmd *exec.Cmd) ([]byte, error) {
+	panic(cmd.Path)
+}
+
+func (*testRunner) ExitCode(cmd *exec.Cmd) int {
+	return 42
+}

--- a/ego/cmd/ego/main.go
+++ b/ego/cmd/ego/main.go
@@ -107,6 +107,23 @@ func main() {
 			help(args[0])
 			return
 		}
+	case "bundle":
+		if len(args) > 0 {
+			var outputFilename string
+			if len(args) > 1 {
+				outputFilename = args[1]
+			}
+			err := c.Bundle(args[0], outputFilename)
+			if err == nil {
+				return
+			}
+			fmt.Println(err)
+			if !os.IsNotExist(err) {
+				// print error only
+				os.Exit(1)
+			}
+			// also print usage
+		}
 	}
 
 	help(cmd)
@@ -220,12 +237,24 @@ Print the UniqueID of a signed executable.`
 Install drivers and other components. The components that you can install depend on your operating system and its version.
 Use "ego install" to list the available components for your system.`
 
+	case "bundle":
+		s = `bundle <executable> [output]
+
+Bundles a signed executable with the current EGo runtime into a single all-in-one executable.
+
+This option is useful if you plan to build and run your enclave on separate systems,
+which might not have EGo installed or uses a different version that is not compatible to the version the executable was built with.
+
+Note that the SGX driver and libraries still need to be installed on the target system in order to execute the bundled executable without issues.
+
+If no output filename is specified, the output binary will be created with the same name as the source executable, appended with "-bundle".`
 	default:
 		s = `<command> [arguments]
 
 Commands:
   sign        Sign an executable built with ego-go.
   run         Run a signed executable in standalone mode.
+  bundle      Bundle a signed executable with the current EGo runtime into a single executable.
   marblerun   Run a signed executable as a Marblerun Marble.
   signerid    Print the SignerID of a signed executable.
   uniqueid    Print the UniqueID of a signed executable.

--- a/ego/internal/launch/buffer.go
+++ b/ego/internal/launch/buffer.go
@@ -1,0 +1,18 @@
+// Copyright (c) Edgeless Systems GmbH.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package launch
+
+// cappedBuffer is a buffer that only takes up to 1000 bytes in total.
+type cappedBuffer []byte
+
+// Write writes until the CappedBuffer is full and silently discards the remainder.
+func (b *cappedBuffer) Write(p []byte) (int, error) {
+	if len(*b) < 1000 {
+		*b = append(*b, p...)
+	}
+	return len(p), nil
+}

--- a/ego/internal/launch/errors.go
+++ b/ego/internal/launch/errors.go
@@ -1,0 +1,72 @@
+// Copyright (c) Edgeless Systems GmbH.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package launch
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// findCommonError translates Edgeless RT / Open Enclave error messages into more user friendly ones.
+func findCommonError(s string) error {
+	switch {
+	case strings.Contains(s, "enclave_initialize failed (err=0x5)"):
+		return ErrEnclIniFailInvalidMeasurement
+	case strings.Contains(s, "enclave_initialize failed (err=0x1001)"):
+		return ErrEnclIniFailUnexpected
+	case strings.Contains(s, "oe_sgx_is_valid_attributes failed: attributes = 0"):
+		return ErrValidAttr0
+	case strings.Contains(s, "ELF image is not a PIE or shared object"):
+		return ErrElfNoPie
+	case strings.Contains(s, "Failed to open Intel SGX device"):
+		return ErrSGXOpenFail
+	case regexp.MustCompile(`enclave_load_data failed \(addr=0x\w+, prot=0x1, err=0x1001\)`).MatchString(s):
+		return ErrLoadDataFailUnexpected
+	default:
+		return nil
+	}
+}
+
+// ErrOEInvalidImg is a representation of Open Enclaves OE_INVALID_IMAGE return code.
+var ErrOEInvalidImg = errors.New("OE_INVALID_IMAGE")
+
+// ErrOEFailure is a representation of Open Enclaves OE_FAILURE return code.
+var ErrOEFailure = errors.New("OE_FAILURE")
+
+// ErrOEPlatform is a representation of Open Enclaves OE_PLATFORM_ERROR return code.
+var ErrOEPlatform = errors.New("OE_PLATFORM_ERROR")
+
+// ErrOECrypto is a representation of Open Enclaves OE_CRYPTO_ERROR return code.
+var ErrOECrypto = errors.New("OE_CRYPTO_ERROR")
+
+// ErrExtUnknown is a unknown error from an external tool.
+var ErrExtUnknown = errors.New("unknown external error")
+
+// ErrEnclIniFailInvalidMeasurement is an Open Enclave error where enclave_initialize fails with error code 0x5.
+// This likely occurs if the signature of the binary is invalid and the binary needs to be resigned.
+var ErrEnclIniFailInvalidMeasurement = fmt.Errorf("%w: enclave_initialize failed: ENCLAVE_INVALID_MEASUREMENT", ErrOEPlatform)
+
+// ErrEnclIniFailUnexpected is an Open Enclave error where enclave_initialize fails with error code 0x1001.
+// On non-FLC systems this occurs if the libsgx-launch package is not installed.
+var ErrEnclIniFailUnexpected = fmt.Errorf("%w: enclave_initialize failed: ENCLAVE_UNEXPECTED", ErrOEPlatform)
+
+// ErrValidAttr0 is an Open Enclave error where oe_sgx_is_valid_attributes fails.
+// This likely occures if an unsigned binary is run.
+var ErrValidAttr0 = fmt.Errorf("%w: oe_sgx_is_valid_attributes failed: attributes = 0", ErrOEFailure)
+
+// ErrElfNoPie is an Open Enclave error where the ELF image is not a PIE or shared object.
+// This likely occures if a binary is run which was not built with ego-go.
+var ErrElfNoPie = fmt.Errorf("%w: ELF image is not a PIE or shared object", ErrOEInvalidImg)
+
+// ErrSGXOpenFail is an Open Enclave error where OE failes to open the Intel SGX device.
+// This likely occures if a system does not support SGX or the required module is missing.
+var ErrSGXOpenFail = fmt.Errorf("%w: Failed to open Intel SGX device", ErrOEPlatform)
+
+// ErrLoadDataFailUnexpected is an Open Enclave error where enclave_load_data fails with error code 0x1001.
+var ErrLoadDataFailUnexpected = fmt.Errorf("%w: enclave_load_data failed: ENCLAVE_UNEXPECTED", ErrOEPlatform)

--- a/ego/internal/launch/launch.go
+++ b/ego/internal/launch/launch.go
@@ -1,0 +1,92 @@
+// Copyright (c) Edgeless Systems GmbH.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package launch
+
+import (
+	"io"
+	"os"
+	"os/exec"
+)
+
+// run launches an application with a CappedBuffer and also translates potential Edgeless RT / Open Enclave errors into more user-friendly ones.
+func run(runner Runner, cmd *exec.Cmd) (int, error) {
+	// force line buffering for stdout
+	// otherwise it will be fully buffered because our stdout is not a tty
+	path, err := exec.LookPath("stdbuf")
+	if err != nil {
+		return 1, err
+	}
+	cmd.Path = path
+	cmd.Args = append([]string{"stdbuf", "-oL"}, cmd.Args...)
+
+	cmd.Stdin = os.Stdin
+
+	// capture stdout and stderr
+	var stdout, stderr cappedBuffer
+	cmd.Stdout = io.MultiWriter(os.Stdout, &stdout)
+	cmd.Stderr = io.MultiWriter(os.Stderr, &stderr)
+
+	if err := runner.Run(cmd); err != nil {
+		if _, ok := err.(*exec.ExitError); !ok {
+			return 1, err
+		}
+	}
+	return runner.ExitCode(cmd), findCommonError(string(stdout) + string(stderr))
+}
+
+// RunEnclave launches an user EGo enclave.
+func RunEnclave(filename string, args []string, egoHostFilename string, egoEnclaveFilename string, runner Runner) (int, error) {
+	enclaves := egoEnclaveFilename + ":" + filename
+	args = append([]string{enclaves}, args...)
+	cmd := exec.Command(egoHostFilename, args...)
+
+	return run(runner, cmd)
+}
+
+// RunEnclaveMarblerun launches an user EGo enclave in MarbleRun mode, calling into MarbleRun's premain before launching user code.
+func RunEnclaveMarblerun(filename string, egoHostFilename string, egoEnclaveFilename string, runner Runner) (int, error) {
+	enclaves := egoEnclaveFilename + ":" + filename
+	cmd := exec.Command(egoHostFilename, enclaves)
+
+	// Enable the Marblerun premain.
+	if err := os.Setenv("EDG_EGO_PREMAIN", "1"); err != nil {
+		return 1, err
+	}
+
+	return run(runner, cmd)
+}
+
+// Runner runs Cmd objects.
+type Runner interface {
+	Run(cmd *exec.Cmd) error
+	Output(cmd *exec.Cmd) ([]byte, error)
+	CombinedOutput(cmd *exec.Cmd) ([]byte, error)
+	ExitCode(cmd *exec.Cmd) int
+}
+
+// OsRunner wraps Cmd objects from the real host system, not an unit test environment.
+type OsRunner struct{}
+
+// Run for OsRunner redirects to cmd.Run()
+func (OsRunner) Run(cmd *exec.Cmd) error {
+	return cmd.Run()
+}
+
+// Output for OsRunner redirects to cmd.Output()
+func (OsRunner) Output(cmd *exec.Cmd) ([]byte, error) {
+	return cmd.Output()
+}
+
+// CombinedOutput for OsRunner redirects to cmd.CombinedOutput()
+func (OsRunner) CombinedOutput(cmd *exec.Cmd) ([]byte, error) {
+	return cmd.CombinedOutput()
+}
+
+// ExitCode for OsRunner redirects to cmd.ProcessState.ExitCode()
+func (OsRunner) ExitCode(cmd *exec.Cmd) int {
+	return cmd.ProcessState.ExitCode()
+}

--- a/ego/internal/launch/untar.go
+++ b/ego/internal/launch/untar.go
@@ -1,0 +1,80 @@
+// Copyright (c) Edgeless Systems GmbH.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package launch
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/afero"
+)
+
+// UntarGzip unpacks a gzip-packed tar archive to the given path.
+// Adapted from: https://medium.com/@skdomino/taring-untaring-files-in-go-6b07cf56bc07
+func UntarGzip(fs afero.Fs, r io.Reader, dst string) error {
+	// Extract the runtime to a temporary directory
+	compressedReader, err := gzip.NewReader(r)
+	if err != nil {
+		return err
+	}
+
+	// Extract the tarball to the temporary directory
+	tarReader := tar.NewReader(compressedReader)
+	for {
+		header, err := tarReader.Next()
+
+		// When done with the archive, stop.
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		if header == nil {
+			continue
+		}
+
+		// Construct path from the entry in the tarball
+		target := filepath.Join(dst, header.Name)
+
+		switch header.Typeflag {
+
+		// Directory
+		case tar.TypeDir:
+			if err := fs.MkdirAll(target, 0o755); err != nil {
+				return err
+			}
+
+		// File
+		case tar.TypeReg:
+			// Tar files do not always have to have a TypeDir object in the header to specify a directory.
+			// They can also be referred to implcitly by a filename with dashes.
+			// Therefore, we also call MkdirAll here to create all upper directories.
+			if err := fs.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return err
+			}
+
+			fsFile, err := fs.OpenFile(target, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
+			if err != nil {
+				return err
+			}
+
+			if _, err := io.Copy(fsFile, tarReader); err != nil {
+				return err
+			}
+
+			if err := fsFile.Close(); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
### Proposed changes
- Add a new binary called 'ego-bundle', which is a self-extractable runtime 
- Add 'ego bundle' CLI command which bundles a signed EGo executable into the 'ego-bundle' binary and create a copy of it
- Unit tests for both of them (including some host I/O, but I tried to limit it to where its necessary)

### Additional info
For this PR I am not sure where to draw the line for code reuse. Many parts, especially for the unit tests are copied from the CLI or main EGo package to avoid calling `NewCLI`, though it is essentially the same code. On the other hand, I also was not sure whether to create an internal package to re-use functions, given that the bundle executable is supposed to pretty much stand on its own... I don't know, let me know in the review about your opinions.

Also don't be scared about the # of lines added, there's more test code involved than the actual functionality :)
