### PR TITLE
docker build: introduce a base image instead of package version pinning

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ DOCKER_BUILDKIT=1 docker build -o. - < Dockerfile.build
 Or build the latest master:
 ```sh
 cd dockerfiles
-DOCKER_BUILDKIT=1 docker build --build-arg base=ubuntu:20.04 --build-arg egotag=master --build-arg erttag=master -o. - < Dockerfile.build
+DOCKER_BUILDKIT=1 docker build --build-arg egotag=master --build-arg erttag=master -o. - < Dockerfile.build
 ```
 This outputs the DEB package.
 

--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ You can reproducibly build the latest release:
 cd dockerfiles
 DOCKER_BUILDKIT=1 docker build -o. - < Dockerfile.build
 ```
-Or the latest master:
+Or build the latest master:
 ```sh
 cd dockerfiles
-DOCKER_BUILDKIT=1 docker build --build-arg egotag=master --build-arg erttag=master -o. - < Dockerfile.build
+DOCKER_BUILDKIT=1 docker build --build-arg base=ubuntu:20.04 --build-arg egotag=master --build-arg erttag=master -o. - < Dockerfile.build
 ```
 This outputs the DEB package.
 

--- a/dockerfiles/Dockerfile.build
+++ b/dockerfiles/Dockerfile.build
@@ -1,17 +1,20 @@
-FROM ubuntu:focal-20220531 AS build
+ARG base_default=ghcr.io/edgelesssys/ego/build-base:v0.5.1
+ARG base=$base_default
+FROM $base AS build
+ARG base_default
+ARG base
 
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y \
-  build-essential=12.8ubuntu1.1 \
-  clang-10=1:10.0.0-4ubuntu1 \
-  cmake=3.16.3-1ubuntu1 \
+RUN test "$base" = "$base_default" || apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+  build-essential \
+  ca-certificates \
+  clang-10 \
+  cmake \
   doxygen \
   git \
-  libssl-dev=1.1.1f-1ubuntu2.13 \
-  locales \
-  ninja-build=1.10.0-1build1 \
-  wget \
-  && locale-gen en_US.UTF-8
-ENV LANG=en_US.UTF-8
+  libssl-dev \
+  ninja-build \
+  wget
 
 ARG erttag=v0.3.3
 ARG egotag=v0.5.1

--- a/dockerfiles/Dockerfile.build
+++ b/dockerfiles/Dockerfile.build
@@ -1,11 +1,7 @@
-ARG base_default=ghcr.io/edgelesssys/ego/build-base:v0.5.1
-ARG base=$base_default
-FROM $base AS build
-ARG base_default
-ARG base
+FROM ghcr.io/edgelesssys/ego/build-base:v0.5.1 AS build
 
-RUN test "$base" = "$base_default" || apt-get update \
-  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+# don't run `apt-get update` because required packages are cached in build-base for reproducibility
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
   build-essential \
   ca-certificates \
   clang-10 \

--- a/dockerfiles/Dockerfile.build-base
+++ b/dockerfiles/Dockerfile.build-base
@@ -1,0 +1,11 @@
+FROM ubuntu:focal-20220531
+RUN apt-get update && apt-get install -dy --no-install-recommends \
+  build-essential \
+  ca-certificates \
+  clang-10 \
+  cmake \
+  doxygen \
+  git \
+  libssl-dev \
+  ninja-build \
+  wget

--- a/samples/reproducible_build/Dockerfile
+++ b/samples/reproducible_build/Dockerfile
@@ -1,29 +1,41 @@
-FROM ubuntu:focal-20210609 AS build
+ARG egover=0.5.1
+FROM ghcr.io/edgelesssys/ego/build-base:v$egover AS build
+ARG egover
 
-RUN apt update && apt install -y \
-  build-essential=12.8ubuntu1.1 \
+# Install required packages
+# These are cached in the build-base image. Don't run `apt-get update` or
+# you may get other package versions and the build won't be reproducible.
+RUN apt-get install -y --no-install-recommends \
+  build-essential \
+  ca-certificates \
   git \
-  gnupg \
   wget
 
-# download, verify, and install ego
-RUN wget -qO- https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add \
-  && echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main' >> /etc/apt/sources.list \
-  && wget https://github.com/edgelesssys/ego/releases/download/v0.3.1/ego_0.3.1_amd64.deb \
-  && echo '5829beb079719095d822bcdcdcfd38a8a07714bdb4281d21bdeaac94beaf4307  ego_0.3.1_amd64.deb' | sha256sum -c \
-  && apt update && apt install -y ./ego_0.3.1_amd64.deb
+# Download and install further requirements (if any)
+#
+# Make sure that these stay the same, e.g., don't use "latest", but fixed versions.
+#
+# Avoid installing packages via apt here. This may change the version of already
+# installed dependencies and may influence the final binary. If not using apt isn't
+# feasible, consider building a Docker image that gathers all required apt packages
+# and serves as a stable base.
 
-# build your app
-RUN git clone -b v0.3.1 --depth=1 https://github.com/edgelesssys/ego \
+# Download and install EGo
+# Use --force-depends to ignore SGX dependencies, which aren't required for building
+RUN wget https://github.com/edgelesssys/ego/releases/download/v$egover/ego_${egover}_amd64.deb \
+  && dpkg -i --force-depends ego_${egover}_amd64.deb
+
+# Build your app
+RUN git clone -b v$egover --depth=1 https://github.com/edgelesssys/ego \
   && cd ego/samples/helloworld \
   && ego-go build -trimpath
 RUN --mount=type=secret,id=signingkey,dst=/ego/samples/helloworld/private.pem,required=true ego sign ego/samples/helloworld/helloworld
 
-# use the deploy target if you want to deploy your app as a Docker image
-FROM ghcr.io/edgelesssys/ego-deploy AS deploy
+# Use the deploy target if you want to deploy your app as a Docker image
+FROM ghcr.io/edgelesssys/ego-deploy:v$egover AS deploy
 COPY --from=build /ego/samples/helloworld/helloworld /
 ENTRYPOINT ["ego", "run", "helloworld"]
 
-# use the export target if you just want to use Docker to build your app and then export it
+# Use the export target if you just want to use Docker to build your app and then export it
 FROM scratch AS export
 COPY --from=build /ego/samples/helloworld/helloworld /


### PR DESCRIPTION
This is another attempt to retain reproducible builds despite gone Ubuntu package versions. It introduces a minimal `build-base` image, which downloads the packages into the cache. Users can override the base image if they want to build with latest packages.

What do you think about this approach?