### PR TITLE
AB#2432: Check for unsupported eclient import

### DIFF
--- a/ego/cli/elf.go
+++ b/ego/cli/elf.go
@@ -1,0 +1,129 @@
+// Copyright (c) Edgeless Systems GmbH.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package cli
+
+import (
+	"debug/elf"
+	"encoding/binary"
+	"errors"
+	"io"
+	"os"
+)
+
+func (c *Cli) embedConfigAsPayload(path string, jsonData []byte) error {
+	// Load ELF executable
+	f, err := c.fs.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	// Check if a payload already exists
+	payloadSize, payloadOffset, oeInfoOffset, err := getPayloadInformation(f)
+	if err != nil {
+		return err
+	}
+
+	// If a payload already exists, truncate the file to remove it
+	if payloadSize > 0 {
+		fileStat, err := f.Stat()
+		if err != nil {
+			return err
+		}
+
+		// Check if payload is at expected location
+		expectedPayloadOffset := fileStat.Size() - int64(payloadSize)
+		if expectedPayloadOffset != payloadOffset {
+			return errors.New("expected payload location does not match real payload location, cannot safely truncate old payload")
+		}
+
+		err = f.Truncate(payloadOffset)
+		if err != nil {
+			return err
+		}
+	} else if (payloadSize == 0) != (payloadOffset == 0) {
+		return errors.New("payload information in header is inconsistent, cannot continue")
+	}
+
+	// Get current file size to determine offset
+	fileStat, err := f.Stat()
+	if err != nil {
+		return err
+	}
+	filesize := fileStat.Size()
+
+	// Write payload offset and size to .oeinfo header
+	if err := writeUint64At(f, uint64(filesize), oeInfoOffset+2048); err != nil {
+		return err
+	}
+	if err := writeUint64At(f, uint64(len(jsonData)), oeInfoOffset+2056); err != nil {
+		return err
+	}
+
+	// And finally, append the payload to the file
+	n, err := f.WriteAt(jsonData, filesize)
+	if err != nil {
+		return err
+	} else if n != len(jsonData) {
+		return errors.New("failed to embed enclave.json as metadata")
+	}
+
+	return nil
+}
+
+func getPayloadInformation(f io.ReaderAt) (uint64, int64, int64, error) {
+	// .oeinfo + 2056 contains the size of an embedded Edgeless RT data payload.
+	// If it is > 0, a payload already exists.
+
+	elfFile, err := elf.NewFile(f)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	oeInfo := elfFile.Section(".oeinfo")
+	if oeInfo == nil {
+		return 0, 0, 0, ErrNoOEInfo
+	}
+
+	payloadOffset, err := readUint64At(oeInfo, 2048)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	payloadSize, err := readUint64At(oeInfo, 2056)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	return payloadSize, int64(payloadOffset), int64(oeInfo.Offset), nil
+}
+
+func writeUint64At(w io.WriterAt, x uint64, off int64) error {
+	xByte := make([]byte, 8)
+	binary.LittleEndian.PutUint64(xByte, x)
+
+	n, err := w.WriteAt(xByte, off)
+	if err != nil {
+		return err
+	} else if n != 8 {
+		return errors.New("did not write expected number of bytes")
+	}
+
+	return nil
+}
+
+func readUint64At(r io.ReaderAt, off int64) (uint64, error) {
+	xByte := make([]byte, 8)
+
+	n, err := r.ReadAt(xByte, off)
+	if err != nil {
+		return 0, err
+	} else if n != 8 {
+		return 0, errors.New("did not read expected number of bytes")
+	}
+
+	return binary.LittleEndian.Uint64(xByte), nil
+}

--- a/ego/cli/elf.go
+++ b/ego/cli/elf.go
@@ -14,9 +14,10 @@ import (
 	"io"
 	"os"
 	"strings"
-
-	"github.com/fatih/color"
 )
+
+// ErrErrUnsupportedImportEClient is returned when an EGo binary uses the eclient package instead of the enclave package.
+var ErrUnsupportedImportEClient = errors.New("unsupported import: github.com/edgelesssys/ego/eclient")
 
 func (c *Cli) embedConfigAsPayload(path string, jsonData []byte) error {
 	// Load ELF executable
@@ -128,11 +129,7 @@ func (c *Cli) checkUnsupportedImports(path string) error {
 	// Iterate through all symbols and find whether it matches a known unsupported one
 	for _, symbol := range symbols {
 		if strings.Contains(symbol.Name, "github.com/edgelesssys/ego/eclient") {
-			boldPrint := color.New(color.Bold).SprintFunc()
-			fmt.Printf("ERROR: You cannot import the %s package within the EGo enclave.\n", boldPrint("github.com/edgelesssys/ego/eclient"))
-			fmt.Printf("It is intended to be used for applications running outside the SGX enclave.\n")
-			fmt.Printf("You can use the %s package as a replacement for usage inside the enclave.\n", boldPrint("github.com/edgelesssys/ego/enclave"))
-			return errors.New("unsupported import: github.com/edgelesssys/ego/eclient")
+			return ErrUnsupportedImportEClient
 		}
 	}
 

--- a/ego/cli/elf_test.go
+++ b/ego/cli/elf_test.go
@@ -1,0 +1,151 @@
+// Copyright (c) Edgeless Systems GmbH.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package cli
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"ego/config"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// create an unsigned EGo executable
+var elfUnsigned = func() []byte {
+	const outFile = "hello"
+	const srcFile = outFile + ".go"
+
+	goroot, err := filepath.Abs(filepath.Join("..", "..", "_ertgo"))
+	if err != nil {
+		panic(err)
+	}
+
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(dir)
+
+	// write minimal source file
+	const src = `package main;import _"time";func main(){}`
+	if err := ioutil.WriteFile(filepath.Join(dir, srcFile), []byte(src), 0o400); err != nil {
+		panic(err)
+	}
+
+	// compile
+	cmd := exec.Command(filepath.Join(goroot, "bin", "go"), "build", srcFile)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GOROOT="+goroot)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		panic(err)
+	}
+
+	// read resulting executable
+	data, err := ioutil.ReadFile(filepath.Join(dir, outFile))
+	if err != nil {
+		panic(err)
+	}
+
+	return data
+}()
+
+func TestEmbedConfigAsPayload(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	// Setup test environment
+	fs := afero.Afero{Fs: afero.NewMemMapFs()}
+	runner := signRunner{fs: fs}
+	cli := NewCli(&runner, fs)
+
+	// Copy from hostfs to memfs
+	const exe = "helloworld"
+	require.NoError(fs.WriteFile(exe, elfUnsigned, 0))
+
+	// Check if no payload exists
+	unsignedExeMemfs, err := fs.Open(exe)
+	require.NoError(err)
+	unsignedExeMemfsStat, err := unsignedExeMemfs.Stat()
+	require.NoError(err)
+	unsignedExeMemfsSize := unsignedExeMemfsStat.Size()
+	payloadSize, payloadOffset, oeInfoOffset, err := getPayloadInformation(unsignedExeMemfs)
+	assert.NoError(err)
+	assert.Zero(payloadSize)
+	assert.Zero(payloadOffset)
+	assert.NotZero(oeInfoOffset)
+	unsignedExeMemfs.Close()
+
+	// Create a default config we want to check
+	testConf := &config.Config{
+		Exe:             exe,
+		Key:             defaultPrivKeyFilename,
+		Debug:           true,
+		HeapSize:        512, //[MB]
+		ProductID:       1,
+		SecurityVersion: 1,
+	}
+
+	// Marshal config
+	jsonData, err := json.Marshal(testConf)
+	require.NoError(err)
+	expectedLengthOfPayload := len(jsonData)
+
+	// Embed json config to helloworld
+	err = cli.embedConfigAsPayload(exe, jsonData)
+	assert.NoError(err)
+
+	// Check if new helloworld_signed now contains signed data
+	signedExeMemfs, err := fs.Open(exe)
+	require.NoError(err)
+	defer signedExeMemfs.Close()
+
+	payloadSize, payloadOffset, oeInfoOffset, err = getPayloadInformation(signedExeMemfs)
+	assert.NoError(err)
+	assert.EqualValues(expectedLengthOfPayload, payloadSize)
+	assert.EqualValues(unsignedExeMemfsSize, payloadOffset)
+	assert.NotZero(oeInfoOffset)
+
+	// Reconstruct the JSON and check equality
+	reconstructedJSON := make([]byte, payloadSize)
+	n, err := signedExeMemfs.ReadAt(reconstructedJSON, payloadOffset)
+	require.NoError(err)
+	require.EqualValues(payloadSize, n)
+	assert.EqualValues(jsonData, reconstructedJSON)
+
+	// Now modify the config, redo everything and see if trucate worked fine and everything still lines up
+	testConf.HeapSize = 5120
+	jsonNewData, err := json.Marshal(testConf)
+	require.NoError(err)
+	expectedLengthOfNewPayload := len(jsonNewData)
+
+	// Re-sign the already signed executable
+	err = cli.embedConfigAsPayload(exe, jsonNewData)
+	assert.NoError(err)
+	payloadSize, payloadOffset, _, err = getPayloadInformation(signedExeMemfs)
+	require.NoError(err)
+	assert.EqualValues(expectedLengthOfNewPayload, payloadSize)
+	assert.EqualValues(unsignedExeMemfsSize, payloadOffset)
+
+	// Reconstruct the JSON and check if it not the old one, but the new one
+	reconstructedJSON = make([]byte, payloadSize)
+	n, err = signedExeMemfs.ReadAt(reconstructedJSON, payloadOffset)
+	require.NoError(err)
+	require.EqualValues(payloadSize, n)
+
+	// Finally, check if we got the new JSON config and not the old one
+	assert.NotEqualValues(jsonData, reconstructedJSON)
+	assert.EqualValues(jsonNewData, reconstructedJSON)
+}

--- a/ego/cli/run.go
+++ b/ego/cli/run.go
@@ -14,11 +14,17 @@ import (
 
 // Run runs a signed executable in standalone mode.
 func (c *Cli) Run(filename string, args []string) (int, error) {
+	if err := c.checkUnsupportedImports(filename); err != nil {
+		return 1, err
+	}
 	return launch.RunEnclave(filename, args, c.getEgoHostPath(), c.getEgoEnclavePath(), c.runner)
 }
 
 // Marblerun runs a signed executable as a MarbleRun Marble.
 func (c *Cli) Marblerun(filename string) (int, error) {
+	if err := c.checkUnsupportedImports(filename); err != nil {
+		return 1, err
+	}
 	return launch.RunEnclaveMarblerun(filename, c.getEgoHostPath(), c.getEgoEnclavePath(), c.runner)
 }
 

--- a/ego/cli/sign.go
+++ b/ego/cli/sign.go
@@ -7,17 +7,15 @@
 package cli
 
 import (
-	"debug/elf"
-	"ego/config"
-	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
+
+	"ego/config"
 )
 
 const (
@@ -189,118 +187,4 @@ func (c *Cli) Sign(filename string) error {
 		return c.signWithJSON(conf)
 	}
 	return c.signExecutable(filename)
-}
-
-func (c *Cli) embedConfigAsPayload(path string, jsonData []byte) error {
-	// Load ELF executable
-	f, err := c.fs.OpenFile(path, os.O_RDWR, 0)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	// Check if a payload already exists
-	payloadSize, payloadOffset, oeInfoOffset, err := getPayloadInformation(f)
-	if err != nil {
-		return err
-	}
-
-	// If a payload already exists, truncate the file to remove it
-	if payloadSize > 0 {
-		fileStat, err := f.Stat()
-		if err != nil {
-			return err
-		}
-
-		// Check if payload is at expected location
-		expectedPayloadOffset := fileStat.Size() - int64(payloadSize)
-		if expectedPayloadOffset != payloadOffset {
-			return errors.New("expected payload location does not match real payload location, cannot safely truncate old payload")
-		}
-
-		err = f.Truncate(payloadOffset)
-		if err != nil {
-			return err
-		}
-	} else if (payloadSize == 0) != (payloadOffset == 0) {
-		return errors.New("payload information in header is inconsistent, cannot continue")
-	}
-
-	// Get current file size to determine offset
-	fileStat, err := f.Stat()
-	if err != nil {
-		return err
-	}
-	filesize := fileStat.Size()
-
-	// Write payload offset and size to .oeinfo header
-	if err := writeUint64At(f, uint64(filesize), oeInfoOffset+2048); err != nil {
-		return err
-	}
-	if err := writeUint64At(f, uint64(len(jsonData)), oeInfoOffset+2056); err != nil {
-		return err
-	}
-
-	// And finally, append the payload to the file
-	n, err := f.WriteAt(jsonData, filesize)
-	if err != nil {
-		return err
-	} else if n != len(jsonData) {
-		return errors.New("failed to embed enclave.json as metadata")
-	}
-
-	return nil
-}
-
-func getPayloadInformation(f io.ReaderAt) (uint64, int64, int64, error) {
-	// .oeinfo + 2056 contains the size of an embedded Edgeless RT data payload.
-	// If it is > 0, a payload already exists.
-
-	elfFile, err := elf.NewFile(f)
-	if err != nil {
-		return 0, 0, 0, err
-	}
-
-	oeInfo := elfFile.Section(".oeinfo")
-	if oeInfo == nil {
-		return 0, 0, 0, ErrNoOEInfo
-	}
-
-	payloadOffset, err := readUint64At(oeInfo, 2048)
-	if err != nil {
-		return 0, 0, 0, err
-	}
-	payloadSize, err := readUint64At(oeInfo, 2056)
-	if err != nil {
-		return 0, 0, 0, err
-	}
-
-	return payloadSize, int64(payloadOffset), int64(oeInfo.Offset), nil
-}
-
-func writeUint64At(w io.WriterAt, x uint64, off int64) error {
-	xByte := make([]byte, 8)
-	binary.LittleEndian.PutUint64(xByte, x)
-
-	n, err := w.WriteAt(xByte, off)
-	if err != nil {
-		return err
-	} else if n != 8 {
-		return errors.New("did not write expected number of bytes")
-	}
-
-	return nil
-}
-
-func readUint64At(r io.ReaderAt, off int64) (uint64, error) {
-	xByte := make([]byte, 8)
-
-	n, err := r.ReadAt(xByte, off)
-	if err != nil {
-		return 0, err
-	} else if n != 8 {
-		return 0, errors.New("did not read expected number of bytes")
-	}
-
-	return binary.LittleEndian.Uint64(xByte), nil
 }

--- a/ego/cli/sign.go
+++ b/ego/cli/sign.go
@@ -28,6 +28,11 @@ const (
 var ErrNoOEInfo = errors.New("could not find .oeinfo section")
 
 func (c *Cli) signWithJSON(conf *config.Config) error {
+	// First, check if the executable does not contain unsupported imports / symbols.
+	if err := c.checkUnsupportedImports(conf.Exe); err != nil {
+		return err
+	}
+
 	// write temp .conf file
 	cProduct := "ProductID=" + strconv.Itoa(conf.ProductID) + "\n"
 	cSecurityVersion := "SecurityVersion=" + strconv.Itoa(conf.SecurityVersion) + "\n"

--- a/ego/cli/sign_test.go
+++ b/ego/cli/sign_test.go
@@ -7,62 +7,20 @@
 package cli
 
 import (
-	"ego/config"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"ego/config"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// create an unsigned EGo executable
-var elfUnsigned = func() []byte {
-	const outFile = "hello"
-	const srcFile = outFile + ".go"
-
-	goroot, err := filepath.Abs(filepath.Join("..", "..", "_ertgo"))
-	if err != nil {
-		panic(err)
-	}
-
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		panic(err)
-	}
-	defer os.RemoveAll(dir)
-
-	// write minimal source file
-	const src = `package main;import _"time";func main(){}`
-	if err := ioutil.WriteFile(filepath.Join(dir, srcFile), []byte(src), 0o400); err != nil {
-		panic(err)
-	}
-
-	// compile
-	cmd := exec.Command(filepath.Join(goroot, "bin", "go"), "build", srcFile)
-	cmd.Dir = dir
-	cmd.Env = append(os.Environ(), "GOROOT="+goroot)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		panic(err)
-	}
-
-	// read resulting executable
-	data, err := ioutil.ReadFile(filepath.Join(dir, outFile))
-	if err != nil {
-		panic(err)
-	}
-
-	return data
-}()
 
 func TestSign(t *testing.T) {
 	const exefile = "exefile"
@@ -232,94 +190,6 @@ ExecutableHeap=1
 			}
 		})
 	}
-}
-
-func TestSignJSONExecutablePayload(t *testing.T) {
-	require := require.New(t)
-	assert := assert.New(t)
-
-	// Setup test environment
-	fs := afero.Afero{Fs: afero.NewMemMapFs()}
-	runner := signRunner{fs: fs}
-	cli := NewCli(&runner, fs)
-
-	// Copy from hostfs to memfs
-	const exe = "helloworld"
-	require.NoError(fs.WriteFile(exe, elfUnsigned, 0))
-
-	// Check if no payload exists
-	unsignedExeMemfs, err := fs.Open(exe)
-	require.NoError(err)
-	unsignedExeMemfsStat, err := unsignedExeMemfs.Stat()
-	require.NoError(err)
-	unsignedExeMemfsSize := unsignedExeMemfsStat.Size()
-	payloadSize, payloadOffset, oeInfoOffset, err := getPayloadInformation(unsignedExeMemfs)
-	assert.NoError(err)
-	assert.Zero(payloadSize)
-	assert.Zero(payloadOffset)
-	assert.NotZero(oeInfoOffset)
-	unsignedExeMemfs.Close()
-
-	// Create a default config we want to check
-	testConf := &config.Config{
-		Exe:             exe,
-		Key:             defaultPrivKeyFilename,
-		Debug:           true,
-		HeapSize:        512, //[MB]
-		ProductID:       1,
-		SecurityVersion: 1,
-	}
-
-	// Marshal config
-	jsonData, err := json.Marshal(testConf)
-	require.NoError(err)
-	expectedLengthOfPayload := len(jsonData)
-
-	// Embed json config to helloworld
-	err = cli.embedConfigAsPayload(exe, jsonData)
-	assert.NoError(err)
-
-	// Check if new helloworld_signed now contains signed data
-	signedExeMemfs, err := fs.Open(exe)
-	require.NoError(err)
-	defer signedExeMemfs.Close()
-
-	payloadSize, payloadOffset, oeInfoOffset, err = getPayloadInformation(signedExeMemfs)
-	assert.NoError(err)
-	assert.EqualValues(expectedLengthOfPayload, payloadSize)
-	assert.EqualValues(unsignedExeMemfsSize, payloadOffset)
-	assert.NotZero(oeInfoOffset)
-
-	// Reconstruct the JSON and check equality
-	reconstructedJSON := make([]byte, payloadSize)
-	n, err := signedExeMemfs.ReadAt(reconstructedJSON, payloadOffset)
-	require.NoError(err)
-	require.EqualValues(payloadSize, n)
-	assert.EqualValues(jsonData, reconstructedJSON)
-
-	// Now modify the config, redo everything and see if trucate worked fine and everything still lines up
-	testConf.HeapSize = 5120
-	jsonNewData, err := json.Marshal(testConf)
-	require.NoError(err)
-	expectedLengthOfNewPayload := len(jsonNewData)
-
-	// Re-sign the already signed executable
-	err = cli.embedConfigAsPayload(exe, jsonNewData)
-	assert.NoError(err)
-	payloadSize, payloadOffset, _, err = getPayloadInformation(signedExeMemfs)
-	require.NoError(err)
-	assert.EqualValues(expectedLengthOfNewPayload, payloadSize)
-	assert.EqualValues(unsignedExeMemfsSize, payloadOffset)
-
-	// Reconstruct the JSON and check if it not the old one, but the new one
-	reconstructedJSON = make([]byte, payloadSize)
-	n, err = signedExeMemfs.ReadAt(reconstructedJSON, payloadOffset)
-	require.NoError(err)
-	require.EqualValues(payloadSize, n)
-
-	// Finally, check if we got the new JSON config and not the old one
-	assert.NotEqualValues(jsonData, reconstructedJSON)
-	assert.EqualValues(jsonNewData, reconstructedJSON)
 }
 
 func TestEmbedFile(t *testing.T) {

--- a/ego/cmd/unsupported-import-test/go.mod
+++ b/ego/cmd/unsupported-import-test/go.mod
@@ -1,0 +1,10 @@
+module example.com/bad-import
+
+go 1.18
+
+require github.com/edgelesssys/ego v1.0.1
+
+require (
+	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa // indirect
+	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
+)

--- a/ego/cmd/unsupported-import-test/go.sum
+++ b/ego/cmd/unsupported-import-test/go.sum
@@ -1,0 +1,11 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/edgelesssys/ego v1.0.1 h1:EZMW7ppQr1Iliv18DIxGIBUmBOWqUmq/RWQ61HW16zE=
+github.com/edgelesssys/ego v1.0.1/go.mod h1:iO7G4U9XISd1XqeqzlzKYvGlFDMLJau+mBvJDjq45x8=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa h1:zuSxTR4o9y82ebqCUJYNGJbGPo6sKVl54f/TVDObg1c=
+golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+gopkg.in/square/go-jose.v2 v2.6.0 h1:NGk74WTnPKBNUhNzQX7PYcTLUjoq7mzKk2OKbvwk2iI=
+gopkg.in/square/go-jose.v2 v2.6.0/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/ego/cmd/unsupported-import-test/main.go
+++ b/ego/cmd/unsupported-import-test/main.go
@@ -1,0 +1,13 @@
+// Copyright (c) Edgeless Systems GmbH.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package main
+
+import "github.com/edgelesssys/ego/eclient"
+
+func main() {
+	eclient.VerifyRemoteReport([]byte{})
+}

--- a/ego/ego/cmd/sign.go
+++ b/ego/ego/cmd/sign.go
@@ -7,18 +7,15 @@
 package cmd
 
 import (
-	"log"
-
-	"ego/cli"
-
 	"github.com/spf13/cobra"
 )
 
 func newSignCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "sign [executable | config.json]",
-		Short: "Sign an executable built with ego-go",
-		Long:  "Sign an executable built with ego-go. Executables must be signed before they can be run in an enclave.",
+		Use:           "sign [executable | config.json]",
+		Short:         "Sign an executable built with ego-go",
+		Long:          "Sign an executable built with ego-go. Executables must be signed before they can be run in an enclave.",
+		SilenceErrors: true,
 		Example: `  ego sign <executable>
     Generates a new key "private.pem" and a default configuration "enclave.json" in the current directory and signs the executable.
 
@@ -36,10 +33,8 @@ func newSignCmd() *cobra.Command {
 				filename = args[0]
 			}
 			err := newCli().Sign(filename)
-			if err == cli.ErrNoOEInfo {
-				log.Fatalln("ERROR: The .oeinfo section is missing in the binary.\nMaybe the binary was not built with 'ego-go build'?")
-			}
-			return err
+			handleErr(err)
+			return err // nil if no error
 		},
 	}
 }

--- a/ego/ego/cmd/signerid.go
+++ b/ego/ego/cmd/signerid.go
@@ -8,9 +8,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
-
-	"ego/internal/launch"
 
 	"github.com/spf13/cobra"
 )
@@ -21,13 +18,12 @@ func newSigneridCmd() *cobra.Command {
 		Short:                 "Print the SignerID of a signed executable",
 		Long:                  "Print the SignerID either from a signed executable or by reading a key file.",
 		Args:                  cobra.ExactArgs(1),
+		SilenceErrors:         true,
 		DisableFlagsInUseLine: true,
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			id, err := newCli().Signerid(args[0])
-			if err == launch.ErrOECrypto {
-				log.Fatalf("ERROR: signerid failed with %v.\nMake sure to pass a valid public key.", err)
-			}
+			handleErr(err)
 			if err != nil {
 				return err
 			}

--- a/ego/ego/cmd/util.go
+++ b/ego/ego/cmd/util.go
@@ -13,6 +13,7 @@ import (
 	"ego/cli"
 	"ego/internal/launch"
 
+	"github.com/fatih/color"
 	"github.com/klauspost/cpuid/v2"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -69,7 +70,16 @@ func handleErr(err error) {
 		fmt.Println("ERROR: failed to initialize the enclave")
 		fmt.Println("Install the SGX base package with: sudo ego install libsgx-enclave-common")
 		fmt.Println("Or temporarily fix the error with: sudo mount -o remount,exec /dev")
+	case launch.ErrOECrypto:
+		fmt.Printf("ERROR: signerid failed with %v.\nMake sure to pass a valid public key.\n", err)
+	case cli.ErrNoOEInfo:
+		fmt.Println("ERROR: The .oeinfo section is missing in the binary.\nMaybe the binary was not built with 'ego-go build'?")
+	case cli.ErrUnsupportedImportEClient:
+		boldPrint := color.New(color.Bold).SprintFunc()
+		fmt.Printf("ERROR: You cannot import the %s package within the EGo enclave.\n", boldPrint("github.com/edgelesssys/ego/eclient"))
+		fmt.Printf("It is intended to be used for applications running outside the SGX enclave.\n")
+		fmt.Printf("You can use the %s package as a replacement for usage inside the enclave.\n", boldPrint("github.com/edgelesssys/ego/enclave"))
 	default:
-		fmt.Println(err)
+		fmt.Println("ERROR:", err)
 	}
 }

--- a/ego/go.mod
+++ b/ego/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 require (
 	github.com/edgelesssys/marblerun v0.6.0
+	github.com/fatih/color v1.13.0
 	github.com/google/go-cmp v0.5.8
 	github.com/klauspost/cpuid/v2 v2.1.0
 	github.com/spf13/afero v1.9.2
@@ -23,6 +24,8 @@ require (
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/mattn/go-colorable v0.1.12 // indirect
+	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/ego/go.sum
+++ b/ego/go.sum
@@ -386,6 +386,7 @@ github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQL
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZMPRZwes7CROmyNKgQzC3XPs6L/G2EJLHddWejkmf4=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
@@ -690,10 +691,12 @@ github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kN
 github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
+github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZbaA40=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-oci8 v0.1.1/go.mod h1:wjDx6Xm9q7dFtHJvIlrI99JytznLw5wQ4R+9mNXJwGI=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=

--- a/src/integration_test.sh
+++ b/src/integration_test.sh
@@ -10,6 +10,7 @@ onexit()
     fi
     rm -r $tPath
     rm -r /tmp/ego-integration-test
+    rm -r /tmp/ego-unsupported-import-test
 }
 
 trap onexit EXIT
@@ -47,3 +48,11 @@ run ego-go build -o /tmp/ego-integration-test/integration-test
 cd /tmp/ego-integration-test
 run ego sign
 run ego run integration-test
+
+# Test unsupported import detection on sign & run
+mkdir -p /tmp/ego-unsupported-import-test
+cd $egoPath/ego/cmd/unsupported-import-test
+run ego-go build -o /tmp/ego-unsupported-import-test/unsupported-import
+cd /tmp/ego-unsupported-import-test
+run ego sign unsupported-import |& grep "unsupported import"
+run ego run unsupported-import |& grep "unsupported import"

--- a/src/integration_test.sh
+++ b/src/integration_test.sh
@@ -54,5 +54,5 @@ mkdir -p /tmp/ego-unsupported-import-test
 cd $egoPath/ego/cmd/unsupported-import-test
 run ego-go build -o /tmp/ego-unsupported-import-test/unsupported-import
 cd /tmp/ego-unsupported-import-test
-run ego sign unsupported-import |& grep "unsupported import"
-run ego run unsupported-import |& grep "unsupported import"
+run ego sign unsupported-import |& grep "You cannot import the github.com/edgelesssys/ego/eclient package"
+run ego run unsupported-import |& grep "You cannot import the github.com/edgelesssys/ego/eclient package"


### PR DESCRIPTION
### Proposed changes
- Check based on ELF sections whether github.com/edgelesssys/ego/eclient was imported on sign or run
- Redirect user to github.com/edgelesssys/ego/enclave instead
- Move some other ELF functions both used by sign.go & bundle.go to elf.go & elf_test.go

The unit test is a bit heavy since it needs a go.mod & go.sum to function. Not sure whether we want to keep it as is or if there is a sleeker way.

### Related issue
- #138 
- Discord support requests
