### PR TITLE
Fix "file exists" error when specifying nested directories for embedded files multiple times

### DIFF
--- a/ego/cmd/integration-test/enclave.json
+++ b/ego/cmd/integration-test/enclave.json
@@ -31,6 +31,10 @@
         {
             "source": "/tmp/ego-integration-test/file-host.txt",
             "target": "/path/to/file_enclave.txt"
+        },
+        {
+            "source": "/tmp/ego-integration-test/file-host.txt",
+            "target": "/path/to/even/deeper/nested/file_enclave.txt"
         }
     ]
 }

--- a/ego/premain/core/core.go
+++ b/ego/premain/core/core.go
@@ -76,6 +76,7 @@ func PreMain(payload string, mounter Mounter, fs afero.Fs, hostEnviron []string)
 			return err
 		}
 
+		// Write embedded files to file system
 		if err := writeFiles(config.Files, fs); err != nil {
 			return err
 		}
@@ -192,7 +193,7 @@ func writeFiles(files []config.File, fs afero.Fs) error {
 		if err != nil {
 			return err
 		}
-		if err := afs.MkdirAll(filepath.Dir(file.Target), 0); err != nil {
+		if err := afs.MkdirAll(filepath.Dir(file.Target), 0o700); err != nil {
 			return err
 		}
 		if err := afs.WriteFile(file.Target, buf, 0o600); err != nil {


### PR DESCRIPTION
### Proposed changes
- Define permissions on `MkdirAll` in premain for embedded files
- Add integration test to test for potential regressions

### Related issue
- Fixes #177 

### Additional info
Like many fixes which eventually end up being one-liners, debugging this issue was a bit of an adventure.

The original issue reports shows that mkdir reports "file exists", which is... interesting, as `MkdirAll` specifically is designed _not_ to return an error when a directory already exists. 

Let's take a look at how MkdirAll is implemented:
https://cs.opensource.google/go/go/+/refs/tags/go1.19.2:src/os/path.go;l=18

First, MkdirAll calls `(os.)Stat` to check whether a file/directory already exists. If it actually is a directory and exists, it returns without an error so this function can be called recursively successfully (See `// Create parent`). If all parents are created, finally `Mkdir` is called to create the child directory (depending on the recursion level).

This means that `os.Stat` must return something unexpected to get to `Mkdir` for an already existing directory in the first place. Indeed, when calling `os.Stat` _in the premain_ on the directory right after the first `MkdirAll` call, it does return "no such file or directory".

Interestingly, when comparing the behavior to a native system and even in EGo itself initially, I could not reproduce the same issue as in the premain. 

After trying out different scenarios and parameters, I could notice the following patterns:

- In a "real" Linux environment, calling something like `os.MkdirAll("a/b/c", 0)` will return "permission denied" when creating `b`, but `os.Stat` works fine on `a`.
- On EGo's in-memory filesystem, calling `os.MkdirAll("a/b/c", 0)` will succeed, but `os.Stat` will fail on any of the directories.
- On EGo's in-memory filesystem, when creating a directory with correct permissions such as `os.MkdirAll("a/b/c", 0o700)`, both `os.MkdirAll` and `os.Stat` will work fine, same as on a real Linux environment.

Turns out setting "0" as the permissions for `os.MkdirAll` triggers the issue... which in itself is probably not a good idea in the first place. But how does this correlate to `os.Stat`?

In the end, it all comes down how we currently call `(f)stat` on the in-memory file system, and the error ending up being rewritten from "Operation not permitted" (EPERM) to "No such file or directory" (ENOENT) due to older code from the previous memory filesystem implementation.

Eventually, we should try to fix these issues in Edgeless RT. But for any real use-case, using sane permissions for files inside the in-memory file system should avoid this issue, and for mounts of the host filesystem this issue does not apply anyway.