### PR TITLE
Wrap error from embedding files to prevent erasure of the manifest

### DIFF
--- a/ego/cli/sign.go
+++ b/ego/cli/sign.go
@@ -24,7 +24,7 @@ const (
 	defaultPubKeyFilename  = "public.pem"
 )
 
-// ErrNoOEInfo defines an error when no .oeinfo section could be found. This likely occures whend the binary to sign was not built with ego-go.
+// ErrNoOEInfo defines an error when no .oeinfo section could be found. This likely occurs when the binary to sign was not built with ego-go.
 var ErrNoOEInfo = errors.New("could not find .oeinfo section")
 
 // errConfigDoesNotExist defines an error when enclave.json or the expected .json file from user input does not exist. It is only used for internal error handling.
@@ -85,7 +85,7 @@ func (c *Cli) signWithJSON(conf *config.Config) error {
 		return err
 	}
 
-	// create public and private key if private key does not exits
+	// create public and private key if private key does not exist
 	c.createDefaultKeypair(conf.Key)
 
 	enclavePath := filepath.Join(c.egoPath, "share", "ego-enclave")


### PR DESCRIPTION
### Proposed changes
- Wrap error from embedding files to prevent erasure of the manifest

This fixes a bug caused when trying to embed a file that does not exist on the host filesystem when calling `ego sign <binary-name>` specifically. It does not occur when calling just `ego sign` or `ego sign enclave.json`.

### Related issue
Discovered this while working on #178

Let's take a look at the implementation of the command for context:
https://github.com/edgelesssys/ego/blob/908ace6f269b62fd0b5134f81da0738badac7267/ego/cli/sign.go#L178-L195

In case no filename or a .json file is specified, the EGo CLI first calls `readConfigJSONtoStruct` and then `signWithJSON`, while when a specific (binary) filename is specified, the EGo CLI calls `signExecutable`.

SignExecutable also calls `readConfigJSONToStruct`, but specifically ignores the "no such files or directory" error by checking `!os.IsNotExist(err)`:
https://github.com/edgelesssys/ego/blob/908ace6f269b62fd0b5134f81da0738badac7267/ego/cli/sign.go#L97-L108

The intention here is to create a new `enclave.json` in case none does exist. 

However, since embedding of the files also happens in this function which also spits out the same "no such file or directory" error in case one is missing, we might accidentally overwrite the manifest with the default template as we handle it with the same error check and _think_ the manifest does not exist, while it's just the files to be embedded that are not at the expected path.

## Proposed solution
While I personally find the call structure a bit confusing and would think of refactoring at some point in the future, the easy fix would be to just wrap the error from embedding the files. That's what this PR does, plus adding some test cases for the unit test to handle all the different call paths for the embedding files test.