### PR TITLE
support relative source paths for hostfs mounts

### DIFF
--- a/ego/cmd/integration-test/enclave.json
+++ b/ego/cmd/integration-test/enclave.json
@@ -13,6 +13,12 @@
             "readOnly": false
         },
         {
+            "source": "relative/path",
+            "target": "/reldata",
+            "type": "hostfs",
+            "readOnly": true
+        },
+        {
             "target": "/memfs",
             "type": "memfs"
         }

--- a/ego/cmd/integration-test/main.go
+++ b/ego/cmd/integration-test/main.go
@@ -51,6 +51,9 @@ func testFileSystemMounts(assert *assert.Assertions, require *require.Assertions
 
 	// Check hostfs mounts specified in manifest
 	log.Println("Testing hostfs mounts...")
+	fileContent, err = os.ReadFile("/reldata/test-file.txt")
+	require.NoError(err)
+	assert.Equal("It relatively works!", string(fileContent))
 	fileContent, err = os.ReadFile("/data/test-file.txt")
 	require.NoError(err)
 	assert.Equal("It works!", string(fileContent))

--- a/src/integration_test.sh
+++ b/src/integration_test.sh
@@ -34,8 +34,9 @@ make install
 export PATH="$tPath/install/bin:$PATH"
 
 # Setup integration test
-mkdir -p /tmp/ego-integration-test
+mkdir -p /tmp/ego-integration-test/relative/path
 echo -n 'It works!' > /tmp/ego-integration-test/test-file.txt
+echo -n 'It relatively works!' > /tmp/ego-integration-test/relative/path/test-file.txt
 echo -n 'i should be in memfs' > /tmp/ego-integration-test/file-host.txt
 
 # Build integration test


### PR DESCRIPTION
Enable users to configure mounts with relative source paths. These will be relative to the CWD of the host process. Implements feature request #186