### PR TITLE
print openssl output on error

### DIFF
--- a/ego/cli/sign.go
+++ b/ego/cli/sign.go
@@ -171,11 +171,13 @@ func (c *Cli) createDefaultKeypair(file string) {
 		}
 		fmt.Println("Generating new " + file)
 		// SGX requires the RSA exponent to be 3. Go's API does not support this.
-		if err := c.runner.Run(exec.Command("openssl", "genrsa", "-out", file, "-3", "3072")); err != nil {
+		if out, err := c.runner.CombinedOutput(exec.Command("openssl", "genrsa", "-out", file, "-3", "3072")); err != nil {
+			fmt.Println(string(out))
 			panic(err)
 		}
 		pubPath := filepath.Join(filepath.Dir(file), defaultPubKeyFilename)
-		if err := c.runner.Run(exec.Command("openssl", "rsa", "-in", file, "-pubout", "-out", pubPath)); err != nil {
+		if out, err := c.runner.CombinedOutput(exec.Command("openssl", "rsa", "-in", file, "-pubout", "-out", pubPath)); err != nil {
+			fmt.Println(string(out))
 			panic(err)
 		}
 	}

--- a/ego/cli/sign_test.go
+++ b/ego/cli/sign_test.go
@@ -275,7 +275,7 @@ type signRunner struct {
 	expectedConfig string
 }
 
-func (s signRunner) Run(cmd *exec.Cmd) error {
+func (signRunner) Run(cmd *exec.Cmd) error {
 	panic(cmd.Path)
 }
 


### PR DESCRIPTION
e2e test with rhel9 container sometimes fails on executing openssl. This should help see the cause next time (and is also better for end users).