### PR TITLE
Notify when a new enclave.json is generated

### DIFF
--- a/ego/cli/sign.go
+++ b/ego/cli/sign.go
@@ -98,6 +98,7 @@ func (c *Cli) signWithJSON(conf *config.Config) error {
 }
 
 func (c *Cli) signExecutable(path string) error {
+	// Try to parse existing config
 	conf, err := c.readConfigJSONtoStruct(defaultConfigFilename)
 
 	if err != nil {
@@ -107,8 +108,11 @@ func (c *Cli) signExecutable(path string) error {
 	} else if conf.Exe == path {
 		return c.signWithJSON(conf)
 	} else {
-		return fmt.Errorf("provided path to executable does not match the one in enclave.json")
+		return fmt.Errorf("provided path to executable does not match the one in %s", defaultConfigFilename)
 	}
+
+	// If there's no suitable existing config, generate a new one.
+	fmt.Println("Generating new", defaultConfigFilename)
 
 	// sane default values
 	conf = &config.Config{


### PR DESCRIPTION
### Proposed changes
- Notify when a new enclave.json is generated
- Added a few comments to make more clear what each code path is supposed to do.

Small inspiration from the short troubleshooting on Discord.
We print a message when a new key pair is generated, but not when a new enclave.json is generated.
Given that you could re-use a key pair but still create a new config, we still might want to notify the user here.

Also added a few comments since the code paths again confused me at first again even though I kinda know the code base 😄 

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->
