### PR TITLE
add ego_largeheap build tag as workaround for heap sizes larger than 16GB

### DIFF
--- a/ego/ego/cmd/util.go
+++ b/ego/ego/cmd/util.go
@@ -77,6 +77,13 @@ func handleErr(err error) {
 		fmt.Println("ERROR: You cannot import the github.com/edgelesssys/ego/eclient package within the EGo enclave.")
 		fmt.Println("It is intended to be used for applications running outside the SGX enclave.")
 		fmt.Println("You can use the github.com/edgelesssys/ego/enclave package as a replacement for usage inside the enclave.")
+	case cli.ErrLargeHeapWithSmallHeapSize:
+		fmt.Println("ERROR: The binary is built with build tag \"ego_largeheap\", but heapSize is set to less than 512.")
+		fmt.Println("Either increase heapSize or rebuild without this build tag.")
+	case cli.ErrNoLargeHeapWithLargeHeapSize:
+		fmt.Println("ERROR: The binary is built without build tag \"ego_largeheap\", but heapSize is set to more than 16384.")
+		fmt.Println("Either decrease heapSize or rebuild with this build tag:")
+		fmt.Println("\tego-go build -tags ego_largeheap ...")
 	default:
 		fmt.Println("ERROR:", err)
 	}

--- a/src/integration_test.sh
+++ b/src/integration_test.sh
@@ -49,6 +49,22 @@ cd /tmp/ego-integration-test
 run ego sign
 run ego run integration-test
 
+# Test heap size check on sign
+sed -i 's/"heapSize": 16,/"heapSize": 16385,/' enclave.json
+run ego sign |& grep "heapSize is set to more than"
+
+# Test ego_largeheap
+cd "$egoPath/ego/cmd/integration-test"
+run ego-go build -o /tmp/ego-integration-test/integration-test -tags ego_largeheap
+cd /tmp/ego-integration-test
+run ego sign  # sign with 16385 heapSize should succeed now
+sed -i 's/"heapSize": 16385,/"heapSize": 511,/' enclave.json
+run ego sign |& grep "heapSize is set to less than"
+# Run integration test built with ego_largeheap and heapSize of 512 MB
+sed -i 's/"heapSize": 511,/"heapSize": 512,/' enclave.json
+run ego sign
+run ego run integration-test
+
 # Test unsupported import detection on sign & run
 mkdir "$tPath/unsupported-import-test"
 cd "$egoPath/ego/cmd/unsupported-import-test"


### PR DESCRIPTION
#201 introduced a regression that causes memory allocations above 16GB to fail. This was reported in #226. It's difficult to support both a small minimal heap size and very large heap sizes within the same built binary.

As a workaround, we introduce the `ego_largeheap` build tag. For most users, the default behavior (small minimal requirements, up to 16GB heap) should be fine. Users wanting larger heap sizes can build their apps with the new build tag.

On signing, the CLI informs the user in case a rebuild with this tag is required.