### PR TITLE
update reproducible_build sample to recent EGo version

### DIFF
--- a/samples/reproducible_build/Dockerfile
+++ b/samples/reproducible_build/Dockerfile
@@ -1,5 +1,11 @@
-ARG egover=1.0.0
+ARG egover=1.4.1
+
+# Use this to build an executable for Ubuntu 22.04
 FROM ghcr.io/edgelesssys/ego/build-base:v${egover} AS build
+
+# Use this to build an executable for Ubuntu 20.04
+# FROM ghcr.io/edgelesssys/ego/build-base-focal:v${egover} AS build
+
 ARG egover
 
 # Install required packages
@@ -22,14 +28,17 @@ RUN apt-get install -y --no-install-recommends \
 
 # Download and install EGo
 # Use --force-depends to ignore SGX dependencies, which aren't required for building
-RUN wget https://github.com/edgelesssys/ego/releases/download/v${egover}/ego_${egover}_amd64.deb \
-  && dpkg -i --force-depends ego_${egover}_amd64.deb
+RUN egodeb=ego_${egover}_amd64_ubuntu-$(grep -oP 'VERSION_ID="\K[^"]+' /etc/os-release).deb \
+  && wget https://github.com/edgelesssys/ego/releases/download/v${egover}/${egodeb} \
+  && dpkg -i --force-depends ${egodeb}
 
 # Build your app
 RUN git clone -b v${egover} --depth=1 https://github.com/edgelesssys/ego \
   && cd ego/samples/helloworld \
   && ego-go build -trimpath
-RUN --mount=type=secret,id=signingkey,dst=/ego/samples/helloworld/private.pem,required=true ego sign ego/samples/helloworld/helloworld
+WORKDIR ego/samples/helloworld
+RUN --mount=type=secret,id=signingkey,dst=private.pem,required=true ego sign helloworld
+RUN ego bundle helloworld
 
 # Use the deploy target if you want to deploy your app as a Docker image
 FROM ghcr.io/edgelesssys/ego-deploy:v${egover} AS deploy
@@ -38,4 +47,4 @@ ENTRYPOINT ["ego", "run", "helloworld"]
 
 # Use the export target if you just want to use Docker to build your app and then export it
 FROM scratch AS export
-COPY --from=build /ego/samples/helloworld/helloworld /
+COPY --from=build /ego/samples/helloworld/helloworld /ego/samples/helloworld/helloworld-bundle /

--- a/samples/reproducible_build/README.md
+++ b/samples/reproducible_build/README.md
@@ -1,20 +1,40 @@
 # Reproducible build
+
 This sample shows how to reproducibly build an EGo application using Docker. The Dockerfile builds the helloworld sample.
 
 First generate a signing key:
+
 ```sh
 openssl genrsa -out private.pem -3 3072
 ```
 
-Either build the `helloworld` executable:
+The Dockerfile builds an executable for Ubuntu 22.04.
+If you need one for Ubuntu 20.04, edit the Dockerfile and switch to the other base image.
+
+Build the `helloworld` executable:
+
 ```console
 $ DOCKER_BUILDKIT=1 docker build --secret id=signingkey,src=private.pem -o. .
 $ ego uniqueid helloworld
-7cb7cc41b6d45b5f5d8517c51650d00961104da2daab93732f7a90909e5f5136
+59e89da6161853814f6916462fed1be4727461bf502ce5865a80c8712cc2f548
 ```
-You should see the same UniqueID as above.
 
-Or build a docker image for deployment:
+You should see the same UniqueID as above if you didn't modify the Dockerfile.
+
+To run the executable, you need to have the same version of EGo installed that is used in the Dockerfile:
+
+```bash
+ego run helloworld
+```
+
+Alternatively, you can use `helloworld-bundle`, which doesn't require an EGo installation:
+
+```bash
+./helloworld-bundle
+```
+
+You can also build a docker image for deployment:
+
 ```sh
 DOCKER_BUILDKIT=1 docker build --secret id=signingkey,src=private.pem --target deploy -t ego-helloworld .
 ```

--- a/samples/reproducible_build/README.md
+++ b/samples/reproducible_build/README.md
@@ -37,4 +37,7 @@ You can also build a docker image for deployment:
 
 ```sh
 DOCKER_BUILDKIT=1 docker build --secret id=signingkey,src=private.pem --target deploy -t ego-helloworld .
+
+# To run the container, expose the SGX devices to it:
+docker run --device /dev/sgx_enclave --device /dev/sgx_provision ego-helloworld
 ```


### PR DESCRIPTION
* Support Ubuntu 20.04 and 22.04
* Add bundled executable to the build so that users don't need the same EGo version installed to try out this sample