### PR TITLE
fix uniqueid and signerid commands if OE_LOG_LEVEL is set

### DIFF
--- a/ego/cli/signerid_test.go
+++ b/ego/cli/signerid_test.go
@@ -14,28 +14,51 @@ import (
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUniqueid(t *testing.T) {
 	assert := assert.New(t)
+	require := require.New(t)
 
-	cli := NewCli(signeridRunner{}, afero.NewMemMapFs())
+	fs := afero.Afero{Fs: afero.NewMemMapFs()}
+	cli := NewCli(nil, fs)
+	const filename = "foo"
 
-	res, err := cli.Uniqueid("foo")
-	assert.NoError(err)
-	assert.Equal("uid foo", res)
+	_, err := cli.Uniqueid(filename)
+	assert.Error(err)
+
+	require.NoError(fs.WriteFile(filename, elfUnsigned, 0))
+
+	res, err := cli.Uniqueid(filename)
+	require.NoError(err)
+	assert.Equal("0000000000000000000000000000000000000000000000000000000000000000", res)
 }
 
-func TestSignerid(t *testing.T) {
+func TestSigneridByExecutable(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fs := afero.Afero{Fs: afero.NewMemMapFs()}
+	cli := NewCli(nil, fs)
+	const filename = "foo"
+
+	_, err := cli.Signerid(filename)
+	assert.Error(err)
+
+	require.NoError(fs.WriteFile(filename, elfUnsigned, 0))
+
+	res, err := cli.Signerid(filename)
+	require.NoError(err)
+	assert.Equal("0000000000000000000000000000000000000000000000000000000000000000", res)
+}
+
+func TestSigneridByKey(t *testing.T) {
 	assert := assert.New(t)
 
 	cli := NewCli(signeridRunner{}, afero.NewMemMapFs())
 
-	res, err := cli.Signerid("foo")
-	assert.NoError(err)
-	assert.Equal("sid foo", res)
-
-	res, err = cli.Signerid("foo.pem")
+	res, err := cli.Signerid("foo.pem")
 	assert.NoError(err)
 	assert.Equal("id foo.pem", res)
 }

--- a/src/integration_test.sh
+++ b/src/integration_test.sh
@@ -44,9 +44,22 @@ cp enclave.json /tmp/ego-integration-test/enclave.json
 export CGO_ENABLED=0  # test that ego-go ignores this
 run ego-go build -o /tmp/ego-integration-test/integration-test
 
-# Sign & run intergration test
+# Sign intergration test
 cd /tmp/ego-integration-test
 run ego sign
+
+# Test id commands
+dump=$(ego-oesign dump -e integration-test)
+run echo "$dump" | grep "^mrenclave=$(ego uniqueid integration-test)$"
+run echo "$dump" | grep "^mrsigner=$(ego signerid integration-test)$"
+run echo "$dump" | grep "^mrsigner=$(ego signerid public.pem)$"
+export OE_LOG_LEVEL=INFO # regression: id commands were broken with OE_LOG_LEVEL set
+run echo "$dump" | grep "^mrenclave=$(ego uniqueid integration-test)$"
+run echo "$dump" | grep "^mrsigner=$(ego signerid integration-test)$"
+run echo "$dump" | grep "^mrsigner=$(ego signerid public.pem)$"
+unset OE_LOG_LEVEL
+
+# Run integration test
 run ego run integration-test
 
 # Test heap size check on sign


### PR DESCRIPTION
The commands invoke oesign to get the values from its stdout. If OE_LOG_LEVEL is, e.g., INFO, it will log something to stdout and parsing fails. The obvious solution would be to unset OE_LOG_LEVEL for the command. But getting the values from the binary is rather simple, so I decided to implement it in Go.