### PR TITLE
close http.Get call

### DIFF
--- a/samples/azure_attestation/ra_client/client.go
+++ b/samples/azure_attestation/ra_client/client.go
@@ -71,7 +71,7 @@ func main() {
 func verifyReportValues(report attestation.Report, signer []byte) error {
 	// You can either verify the UniqueID or the tuple (SignerID, ProductID, SecurityVersion, Debug).
 
-	if !bytes.Equal(report.SignerID, []byte(signer)) {
+	if !bytes.Equal(report.SignerID, signer) {
 		return errors.New("token does not contain the right signer id")
 	}
 	fmt.Println("✅ SignerID of the report equals the SignerID you passed to the client.")

--- a/samples/embedded_file/main.go
+++ b/samples/embedded_file/main.go
@@ -12,8 +12,7 @@ func main() {
 		panic(err)
 	}
 	fmt.Println(resp.Status)
-	err = resp.Body.Close()
-	if err != nil {
+	if err := resp.Body.Close(); err != nil {
 		panic(err)
 	}
 }

--- a/samples/embedded_file/main.go
+++ b/samples/embedded_file/main.go
@@ -12,4 +12,8 @@ func main() {
 		panic(err)
 	}
 	fmt.Println(resp.Status)
+	err = resp.Body.Close()
+	if err != nil {
+		panic(err)
+	}
 }


### PR DESCRIPTION
### Proposed changes
- close http.Get call as per https://pkg.go.dev/net/http#Client.Do

"If the returned error is nil, the [Response](https://pkg.go.dev/net/http#Response) will contain a non-nil Body which the user is expected to close."