### PR TITLE
allow building newer go module versions

### DIFF
--- a/ego/cmd/newer-go-ver-test/go.mod
+++ b/ego/cmd/newer-go-ver-test/go.mod
@@ -1,0 +1,7 @@
+module example.com/newer-go-ver-test
+
+go 1.99
+
+replace example.com/testmod => ./testmod
+
+require example.com/testmod v0.0.0-00010101000000-000000000000

--- a/ego/cmd/newer-go-ver-test/main.go
+++ b/ego/cmd/newer-go-ver-test/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "example.com/testmod"
+
+func main() {
+	testmod.Hello()
+}

--- a/ego/cmd/newer-go-ver-test/testmod/go.mod
+++ b/ego/cmd/newer-go-ver-test/testmod/go.mod
@@ -1,0 +1,3 @@
+module example.com/testmod
+
+go 1.98

--- a/ego/cmd/newer-go-ver-test/testmod/testmod.go
+++ b/ego/cmd/newer-go-ver-test/testmod/testmod.go
@@ -1,0 +1,7 @@
+package testmod
+
+import "fmt"
+
+func Hello() {
+	fmt.Println("hello from testmod")
+}

--- a/src/integration_test.sh
+++ b/src/integration_test.sh
@@ -98,3 +98,11 @@ run ego sign enclave2.json
 keyid2=$(ego run sealkeyid-test)
 echo 'test keyid1 = keyid2'
 test "$keyid1" = "$keyid2"
+
+# Test building module with newer go version
+mkdir "$tPath/newer-go-ver-test"
+cd "$egoPath/ego/cmd/newer-go-ver-test"
+run ego-go build -o "$tPath/newer-go-ver-test"
+cd "$tPath/newer-go-ver-test"
+run ego sign newer-go-ver-test
+run ego run newer-go-ver-test


### PR DESCRIPTION
Since Go 1.21, the compiler enforces that its version is >= the highest version of all involved modules. This check includes the patch version. This is impractical within EGo, so we let the compiler print a warning instead.