### PR TITLE
fix env var from host truncated at equal sign

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,10 @@ project(ego VERSION 1.5.0)
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Debug)
 endif()
-if(NOT CMAKE_BUILD_TYPE STREQUAL Debug)
+if(CMAKE_BUILD_TYPE STREQUAL Debug)
+  # disable optimizations to improve debugging with gdb
+  set(PREMAIN_DEBUG_FLAGS -gcflags=all='-N -l')
+else()
   set(TRIMPATH -trimpath)
 endif()
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
@@ -39,7 +42,7 @@ target_link_libraries(ego-enclave-lib PRIVATE openenclave::oe_includes)
 add_custom_command(
   OUTPUT premain.a
   DEPENDS ego/premain/main.go ego/premain/core/core.go
-  COMMAND ertgo build -buildmode=c-archive -o ${CMAKE_BINARY_DIR} ${TRIMPATH}
+  COMMAND ertgo build -buildmode=c-archive -o ${CMAKE_BINARY_DIR} ${TRIMPATH} ${PREMAIN_DEBUG_FLAGS}
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/ego/premain)
 add_custom_target(premainbuild DEPENDS premain.a)
 

--- a/docs/docs/workflows/debug.md
+++ b/docs/docs/workflows/debug.md
@@ -8,7 +8,10 @@ An EGo executable can be run as a normal host process without an enclave. Thus, 
 
 ## Inside an enclave
 
-EGo comes with `ego-gdb` that augments `gdb` with enclave support. The `console` interface is the same as `gdb`:
+EGo comes with `ego-gdb` that augments `gdb` with enclave support.
+For a better debugging experience with it, compile your app without optimizations by passing `-gcflags=all="-N -l"` to `ego-go build`.
+
+The `console` interface of `ego-gdb` is the same as `gdb`:
 
 ```bash
 ego-gdb --args ./helloworld

--- a/ego/premain/core/core.go
+++ b/ego/premain/core/core.go
@@ -51,8 +51,8 @@ func PreMain(payload string, mounter Mounter, fs afero.Fs, hostEnviron []string)
 	// Convert host environment string array to key-value map
 	hostEnvironMap := make(map[string]string, len(hostEnviron))
 	for _, envVar := range hostEnviron {
-		splitString := strings.Split(envVar, "=")
-		hostEnvironMap[splitString[0]] = splitString[1]
+		envName, envValue, _ := strings.Cut(envVar, "=")
+		hostEnvironMap[envName] = envValue
 	}
 
 	// Check if we run as a Marble or a normal EGo application

--- a/ego/premain/core/core_test.go
+++ b/ego/premain/core/core_test.go
@@ -33,7 +33,7 @@ func TestPremain(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	hostEnviron := []string{"EDG_CWD=/host"}
+	hostEnviron := []string{"EDG_CWD=/host", "EDG_CONTAINS_EQUAL_SIGN=foo=bar"}
 	fs := afero.NewMemMapFs()
 
 	// sane default values
@@ -51,6 +51,7 @@ func TestPremain(t *testing.T) {
 	// Supply valid payload, no Marble
 	mounter := assertionMounter{assert: assert, expectedMounts: conf.Mounts, usedTargets: make(map[string]bool), remountAsHostFS: false}
 	assert.NoError(PreMain("", &mounter, fs, hostEnviron))
+	assert.Equal("foo=bar", os.Getenv("EDG_CONTAINS_EQUAL_SIGN"))
 
 	// Supply valid payload, no Marble
 	payload, err := json.Marshal(conf)


### PR DESCRIPTION
* first commit improves debugging with gdb by disabling some Go optimizations
* second commit fixes the bug where an env var from host like `FOO=bar=baz` was truncated to the value `bar`