### PR TITLE
support stripped executables

### DIFF
--- a/ego/cli/elf.go
+++ b/ego/cli/elf.go
@@ -157,10 +157,13 @@ func (c *Cli) readDataFromELF(path string, section string, offset int, size int)
 // checkUnsupportedImports checks whether the to-be-signed or to-be-executed binary uses Go imports which are not supported.
 func (c *Cli) checkUnsupportedImports(path string) error {
 	symbols, err := c.getSymbolsFromELF(path)
-	if err != nil {
-		return fmt.Errorf("getting symbols: %w", err)
+	if err == nil {
+		return checkUnsupportedImports(symbols)
 	}
-	return checkUnsupportedImports(symbols)
+	if errors.Is(err, elf.ErrNoSymbols) {
+		return nil
+	}
+	return fmt.Errorf("getting symbols: %w", err)
 }
 
 func checkUnsupportedImports(symbols []elf.Symbol) error {

--- a/ego/cli/sign.go
+++ b/ego/cli/sign.go
@@ -7,6 +7,7 @@
 package cli
 
 import (
+	"debug/elf"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -31,19 +32,18 @@ var ErrNoOEInfo = errors.New("could not find .oeinfo section")
 var errConfigDoesNotExist = errors.New("enclave config file not found")
 
 func (c *Cli) signWithJSON(conf *config.Config) error {
-	symbols, err := c.getSymbolsFromELF(conf.Exe)
-	if err != nil {
+	if symbols, err := c.getSymbolsFromELF(conf.Exe); err == nil {
+		// First, check if the executable does not contain unsupported imports / symbols.
+		if err := checkUnsupportedImports(symbols); err != nil {
+			return err
+		}
+
+		// Check that heapSize is in the supported range of the heap mode the binary was built with.
+		if err := checkHeapMode(symbols, conf.HeapSize); err != nil {
+			return err
+		}
+	} else if !errors.Is(err, elf.ErrNoSymbols) {
 		return fmt.Errorf("getting symbols: %w", err)
-	}
-
-	// First, check if the executable does not contain unsupported imports / symbols.
-	if err := checkUnsupportedImports(symbols); err != nil {
-		return err
-	}
-
-	// Check that heapSize is in the supported range of the heap mode the binary was built with.
-	if err := checkHeapMode(symbols, conf.HeapSize); err != nil {
-		return err
 	}
 
 	// write temp .conf file

--- a/src/integration_test.sh
+++ b/src/integration_test.sh
@@ -78,6 +78,14 @@ sed -i 's/"heapSize": 511,/"heapSize": 768,/' enclave.json
 run ego sign
 run ego run integration-test
 
+# Test stripped executable
+cd "$egoPath/ego/cmd/integration-test"
+cp enclave.json /tmp/ego-integration-test/enclave.json
+run ego-go build -o /tmp/ego-integration-test/integration-test -ldflags -s
+cd /tmp/ego-integration-test
+run ego sign
+run ego run integration-test
+
 # Test unsupported import detection on sign & run
 mkdir "$tPath/unsupported-import-test"
 cd "$egoPath/ego/cmd/unsupported-import-test"


### PR DESCRIPTION
OE supports stripped executables since v0.18.0. EGo uses symbols to check for some user mistakes. Skip these if no symbols are present so that EGo also supports stripped executables.