### PR TITLE
add advisory list to attestation report

### DIFF
--- a/attestation/attestation.go
+++ b/attestation/attestation.go
@@ -15,13 +15,15 @@ import (
 
 // Report is a parsed enclave report.
 type Report struct {
-	Data            []byte           // The report data that has been included in the report.
-	SecurityVersion uint             // Security version of the enclave. For SGX enclaves, this is the ISVSVN value.
-	Debug           bool             // If true, the report is for a debug enclave.
-	UniqueID        []byte           // The unique ID for the enclave. For SGX enclaves, this is the MRENCLAVE value.
-	SignerID        []byte           // The signer ID for the enclave. For SGX enclaves, this is the MRSIGNER value.
-	ProductID       []byte           // The Product ID for the enclave. For SGX enclaves, this is the ISVPRODID value.
-	TCBStatus       tcbstatus.Status // The status of the enclave's TCB level.
+	Data             []byte           // The report data that has been included in the report.
+	SecurityVersion  uint             // Security version of the enclave. For SGX enclaves, this is the ISVSVN value.
+	Debug            bool             // If true, the report is for a debug enclave.
+	UniqueID         []byte           // The unique ID for the enclave. For SGX enclaves, this is the MRENCLAVE value.
+	SignerID         []byte           // The signer ID for the enclave. For SGX enclaves, this is the MRSIGNER value.
+	ProductID        []byte           // The Product ID for the enclave. For SGX enclaves, this is the ISVPRODID value.
+	TCBStatus        tcbstatus.Status // The status of the enclave's TCB level.
+	TCBAdvisories    []string         // IDs of Intel security advisories that provide insight into the reasons when the TCB status is not UpToDate.
+	TCBAdvisoriesErr error            // Error that occurred while getting the advisory array (if any).
 }
 
 var (
@@ -51,12 +53,5 @@ func VerifyAzureAttestationToken(token string, providerURL string) (Report, erro
 	if err != nil {
 		return Report{}, err
 	}
-	return Report{
-		Data:            report.Data,
-		SecurityVersion: report.SecurityVersion,
-		Debug:           report.Debug,
-		UniqueID:        report.UniqueID,
-		SignerID:        report.SignerID,
-		ProductID:       report.ProductID,
-	}, nil
+	return Report(report), nil
 }

--- a/enclave/ert.go
+++ b/enclave/ert.go
@@ -106,15 +106,7 @@ func VerifyRemoteReport(reportBytes []byte) (attestation.Report, error) {
 	if err != nil {
 		return attestation.Report{}, err
 	}
-	return attestation.Report{
-		Data:            report.Data,
-		SecurityVersion: report.SecurityVersion,
-		Debug:           report.Debug,
-		UniqueID:        report.UniqueID,
-		SignerID:        report.SignerID,
-		ProductID:       report.ProductID,
-		TCBStatus:       report.TCBStatus,
-	}, verifyErr
+	return attestation.Report(report), verifyErr
 }
 
 // GetLocalReport gets a report signed by the enclave platform for use in local attestation.

--- a/internal/attestation/attestation.go
+++ b/internal/attestation/attestation.go
@@ -25,13 +25,15 @@ import (
 
 // Report is a parsed enclave report.
 type Report struct {
-	Data            []byte           // The report data that has been included in the report.
-	SecurityVersion uint             // Security version of the enclave. For SGX enclaves, this is the ISVSVN value.
-	Debug           bool             // If true, the report is for a debug enclave.
-	UniqueID        []byte           // The unique ID for the enclave. For SGX enclaves, this is the MRENCLAVE value.
-	SignerID        []byte           // The signer ID for the enclave. For SGX enclaves, this is the MRSIGNER value.
-	ProductID       []byte           // The Product ID for the enclave. For SGX enclaves, this is the ISVPRODID value.
-	TCBStatus       tcbstatus.Status // The status of the enclave's TCB level.
+	Data             []byte           // The report data that has been included in the report.
+	SecurityVersion  uint             // Security version of the enclave. For SGX enclaves, this is the ISVSVN value.
+	Debug            bool             // If true, the report is for a debug enclave.
+	UniqueID         []byte           // The unique ID for the enclave. For SGX enclaves, this is the MRENCLAVE value.
+	SignerID         []byte           // The signer ID for the enclave. For SGX enclaves, this is the MRSIGNER value.
+	ProductID        []byte           // The Product ID for the enclave. For SGX enclaves, this is the ISVPRODID value.
+	TCBStatus        tcbstatus.Status // The status of the enclave's TCB level.
+	TCBAdvisories    []string         // IDs of Intel security advisories that provide insight into the reasons when the TCB status is not UpToDate.
+	TCBAdvisoriesErr error            // Error that occurred while getting the advisory array (if any).
 }
 
 // https://github.com/openenclave/openenclave/blob/master/include/openenclave/internal/report.h

--- a/internal/attestation/claim.h
+++ b/internal/attestation/claim.h
@@ -22,3 +22,5 @@ typedef struct _oe_claim
 #define OE_CLAIM_PRODUCT_ID "product_id"
 #define OE_CLAIM_TCB_STATUS "tcb_status"
 #define OE_CLAIM_SGX_REPORT_DATA "sgx_report_data"
+#define OE_CLAIM_SGX_TCB_INFO "sgx_tcb_info"
+#define OE_CLAIM_SGX_TCB_INFO_INDEX "sgx_tcb_info_index"

--- a/internal/attestation/claim_test.go
+++ b/internal/attestation/claim_test.go
@@ -1,0 +1,94 @@
+package attestation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetAdvisoriesFromTCBInfo(t *testing.T) {
+	const tcbInfo = `
+{
+	"tcbInfo": {
+		"tcbLevels": [
+			{
+				"tcbStatus": "UpToDate"
+			},
+			{
+				"tcbStatus": "OutOfDate",
+				"advisoryIDs": [
+					"id 1"
+				]
+			},
+			{
+				"tcbStatus": "OutOfDate",
+				"advisoryIDs": [
+					"id 2",
+					"id 3",
+					"id 4"
+				]
+			}
+		]
+	}
+}
+`
+
+	testCases := map[string]struct {
+		info           string
+		index          uint
+		wantErr        bool
+		wantAdvisories []string
+	}{
+		"0 advisories at index 0": {
+			info:  tcbInfo,
+			index: 0,
+		},
+		"1 advisory at index 1": {
+			info:           tcbInfo,
+			index:          1,
+			wantAdvisories: []string{"id 1"},
+		},
+		"3 advisories at index 2": {
+			info:           tcbInfo,
+			index:          2,
+			wantAdvisories: []string{"id 2", "id 3", "id 4"},
+		},
+		"error at index 3": {
+			info:    tcbInfo,
+			index:   3,
+			wantErr: true,
+		},
+		"no TCB info": {
+			info:    "",
+			index:   0,
+			wantErr: true,
+		},
+		"null-terminated TCB info": {
+			info:           tcbInfo + "\x00",
+			index:          1,
+			wantAdvisories: []string{"id 1"},
+		},
+		"multiple null terminators": {
+			info:           tcbInfo + "\x00\x00\x00",
+			index:          1,
+			wantAdvisories: []string{"id 1"},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			advisories, err := getAdvisoriesFromTCBInfo([]byte(tc.info), tc.index)
+			if tc.wantErr {
+				assert.Error(err)
+				return
+			}
+			require.NoError(err)
+
+			assert.Equal(tc.wantAdvisories, advisories)
+		})
+	}
+}


### PR DESCRIPTION
Add `TCBAdvisories` to the attestation report so that a user can learn why the verified platform has a certain `TCBStatus`.
Don't let attestation fail when an error occurs while getting the advisory array, but return it in `TCBAdvisoriesErr`. Let the user decide how to handle the error.