### PR TITLE
update PCCS to last available release and make API key optional

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -19,3 +19,4 @@ jobs:
         with:
           files: docs/docs
           fail_on_error: true
+          version: 3.9.3

--- a/docs/docs/reference/attest.md
+++ b/docs/docs/reference/attest.md
@@ -62,18 +62,17 @@ If you're running an EGo app on premises, you must host a PCCS yourself.
 
 #### Set up the PCCS
 
-To set up a PCCS, you can either follow [the instructions from Intel](https://www.intel.com/content/www/us/en/developer/articles/guide/intel-software-guard-extensions-data-center-attestation-primitives-quick-install-guide.html) or use our provided Docker image.
+To set up a PCCS, you can either follow [the instructions from Intel](https://download.01.org/intel-sgx/latest/dcap-latest/linux/docs/Intel_SGX_SW_Installation_Guide_for_Linux.pdf) or use our provided Docker image.
 
 To do the latter, follow these steps:
 
-1. Register with [Intel](https://api.portal.trustedservices.intel.com/provisioning-certification) to get a PCCS API key
-2. Run the PCCS:
+1. Run the PCCS:
 
    ```bash
-   docker run -e APIKEY=<your-API-key> -p 8081:8081 --name pccs -d ghcr.io/edgelesssys/pccs
+   docker run -p 8081:8081 --name pccs -d ghcr.io/edgelesssys/pccs
    ```
 
-3. Verify that the PCCS is running:
+2. Verify that the PCCS is running:
 
    ```bash
    curl -kv https://localhost:8081/sgx/certification/v4/rootcacrl

--- a/pccs/Dockerfile
+++ b/pccs/Dockerfile
@@ -1,0 +1,77 @@
+# Copyright (c) 2024 Intel Corporation
+
+# Declare nodejs version you want to use
+ARG NODE_VERSION=20.11.1
+
+# Use multi-stage builds to reduce final image size
+FROM docker.io/library/debian AS builder
+
+# Define arguments used across multiple stages
+ARG DCAP_VERSION=DCAP_1.21
+ARG NODE_VERSION
+
+# update and install packages, nodejs
+RUN DEBIAN_FRONTEND=noninteractive \
+    apt-get update -yq \
+    && apt-get upgrade -yq \
+    && apt-get install -yq --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        curl \
+        gnupg \
+        git \
+        zip \
+        python3 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install nvm (Node Version Manager)
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+
+# Set NVM_DIR so we can use it in subsequent commands
+ENV NVM_DIR /root/.nvm
+
+# Install specific version of Node using nvm
+# Source nvm in each RUN command to ensure it's available
+RUN . "$NVM_DIR/nvm.sh" && nvm install $NODE_VERSION && nvm use $NODE_VERSION
+
+# Set PATH to include the node and npm binaries
+ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+
+# Clone the specific branch or tag 
+RUN git clone --recurse-submodules https://github.com/intel/SGXDataCenterAttestationPrimitives.git -b ${DCAP_VERSION} --depth 1
+
+# Build libPCKCertSelection library
+WORKDIR /SGXDataCenterAttestationPrimitives/tools/PCKCertSelection/
+RUN make \
+    && mkdir -p ../../QuoteGeneration/pccs/lib \
+    && cp ./out/libPCKCertSelection.so ../../QuoteGeneration/pccs/lib/ \
+    && make clean
+
+# Build PCCS
+WORKDIR /SGXDataCenterAttestationPrimitives/QuoteGeneration/pccs/
+RUN npm config set proxy $http_proxy \
+    && npm config set https-proxy $https_proxy \
+    && npm config set engine-strict true \
+    && npm install
+
+# Start final image build
+FROM docker.io/library/debian:12-slim
+
+ARG NODE_VERSION
+
+# Create user and group before copying files
+ARG USER=pccs
+RUN useradd -M -U -r ${USER} -s /bin/false
+
+# Copy only necessary files from builder stage
+COPY --from=builder /root/.nvm/versions/node/v$NODE_VERSION/bin/node /usr/bin/node
+COPY --from=builder --chown=${USER}:${USER} /SGXDataCenterAttestationPrimitives/QuoteGeneration/pccs/ /opt/intel/pccs/
+
+# Set the working directory and switch user
+WORKDIR /opt/intel/pccs/
+USER ${USER}
+
+# Define entrypoint
+ENTRYPOINT ["/usr/bin/node", "pccs_server.js"]
+

--- a/pccs/Dockerfile
+++ b/pccs/Dockerfile
@@ -1,4 +1,31 @@
-# Copyright (c) 2024 Intel Corporation
+# Copyright (C) 2021 Edgeless Systems GmbH. All rights reserved.
+# Copyright (C) 2011-2021 Intel Corporation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#   * Neither the name of Intel Corporation nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 # Declare nodejs version you want to use
 ARG NODE_VERSION=20.11.1
@@ -38,7 +65,7 @@ RUN . "$NVM_DIR/nvm.sh" && nvm install $NODE_VERSION && nvm use $NODE_VERSION
 # Set PATH to include the node and npm binaries
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
-# Clone the specific branch or tag 
+# Clone the specific branch or tag
 RUN git clone --recurse-submodules https://github.com/intel/SGXDataCenterAttestationPrimitives.git -b ${DCAP_VERSION} --depth 1
 
 # Build libPCKCertSelection library
@@ -50,6 +77,9 @@ RUN make \
 
 # Build PCCS
 WORKDIR /SGXDataCenterAttestationPrimitives/QuoteGeneration/pccs/
+# EDG: apply patch that makes apikey optional
+COPY apikey.patch .
+RUN git apply apikey.patch
 RUN npm config set proxy $http_proxy \
     && npm config set https-proxy $https_proxy \
     && npm config set engine-strict true \
@@ -57,6 +87,9 @@ RUN npm config set proxy $http_proxy \
 
 # Start final image build
 FROM docker.io/library/debian:12-slim
+
+# EDG: install openssl for generating temporary keys
+RUN apt-get update && apt-get install -y openssl && rm -rf /var/lib/apt/lists/*
 
 ARG NODE_VERSION
 
@@ -75,3 +108,6 @@ USER ${USER}
 # Define entrypoint
 ENTRYPOINT ["/usr/bin/node", "pccs_server.js"]
 
+# EDG: override entrypoint
+COPY setup.sh .
+ENTRYPOINT ["./setup.sh"]

--- a/pccs/README.md
+++ b/pccs/README.md
@@ -1,0 +1,32 @@
+# PCCS Server
+
+## Build your ready to use PCCS Server using docker
+
+### Prerequisites
+In order to establish a connection to Intels PCS API, the PCCS needs to be configured with an API key.
+To get your free API key, go to https://api.portal.trustedservices.intel.com/provisioning-certification, create an account and click on "Subscribe".
+
+You should then see two keys. Use either the primary or the second one as your API key in the following.
+
+### Build via Docker
+
+Build the pccs image:
+```bash
+docker build --tag ghcr.io/edgelesssys/pccs pccs
+```
+
+### Run the docker image
+
+After you've build the image, run it using docker. It is important that you paste your API key in the run command.
+
+*Note*: Optionally you can configure your PCCS with a custom user password (`-e USERPASS=<user-pwd>`)
+and a custom admin password <br/>(`-e ADMINPASS=<admin-pwd>`), but in most cases there is no need to do that.
+```bash
+docker run -e APIKEY=<your-API-key> -p 8081:8081 --name pccs -d pccs
+```
+
+The PCCS is now available on port 8081. Verify that your PCCS Server runs correctly:
+```bash
+curl --noproxy "*" -v -k -G "https://localhost:8081/sgx/certification/v3/rootcacrl"
+```
+You should see a 200 status code. This means your PCCS Server is able to deliver data for your applications!

--- a/pccs/README.md
+++ b/pccs/README.md
@@ -2,31 +2,27 @@
 
 ## Build your ready to use PCCS Server using docker
 
-### Prerequisites
-In order to establish a connection to Intels PCS API, the PCCS needs to be configured with an API key.
-To get your free API key, go to https://api.portal.trustedservices.intel.com/provisioning-certification, create an account and click on "Subscribe".
-
-You should then see two keys. Use either the primary or the second one as your API key in the following.
-
-### Build via Docker
-
 Build the pccs image:
+
 ```bash
-docker build --tag ghcr.io/edgelesssys/pccs pccs
+docker build --tag pccs .
 ```
 
-### Run the docker image
+## Run the docker image
 
-After you've build the image, run it using docker. It is important that you paste your API key in the run command.
+After you've build the image, run it using docker.
 
 *Note*: Optionally you can configure your PCCS with a custom user password (`-e USERPASS=<user-pwd>`)
-and a custom admin password <br/>(`-e ADMINPASS=<admin-pwd>`), but in most cases there is no need to do that.
+and a custom admin password (`-e ADMINPASS=<admin-pwd>`), but in most cases there is no need to do that.
+
 ```bash
-docker run -e APIKEY=<your-API-key> -p 8081:8081 --name pccs -d pccs
+docker run -p 8081:8081 --name pccs -d pccs
 ```
 
 The PCCS is now available on port 8081. Verify that your PCCS Server runs correctly:
+
 ```bash
-curl --noproxy "*" -v -k -G "https://localhost:8081/sgx/certification/v3/rootcacrl"
+curl --noproxy "*" -v -k -G "https://localhost:8081/sgx/certification/v4/rootcacrl"
 ```
+
 You should see a 200 status code. This means your PCCS Server is able to deliver data for your applications!

--- a/pccs/apikey.patch
+++ b/pccs/apikey.patch
@@ -1,0 +1,40 @@
+diff --git a/QuoteGeneration/pccs/pcs_client/pcs_client.js b/QuoteGeneration/pccs/pcs_client/pcs_client.js
+index cf675a8..8872676 100644
+--- a/QuoteGeneration/pccs/pcs_client/pcs_client.js
++++ b/QuoteGeneration/pccs/pcs_client/pcs_client.js
+@@ -66,7 +66,7 @@ async function do_request(url, options) {
+       if (!options.headers) {
+         options.headers = {};
+       }
+-      options.headers['Ocp-Apim-Subscription-Key'] = Config.get('ApiKey');
++      const apikey = Config.get('ApiKey'); if (apikey) options.headers['Ocp-Apim-Subscription-Key'] = apikey;
+     }
+ 
+     // global opitons ( proxy, timeout, etc)
+@@ -128,9 +128,11 @@ export async function getCerts(enc_ppid, pceid) {
+       pceid: pceid,
+     },
+     method: 'GET',
+-    headers: { 'Ocp-Apim-Subscription-Key': Config.get('ApiKey') },
++    headers: {},
+   };
+ 
++  const apikey = Config.get('ApiKey'); if (apikey) options.headers['Ocp-Apim-Subscription-Key'] = apikey;
++
+   return do_request(Config.get('uri') + 'pckcerts', options);
+ }
+ 
+@@ -142,11 +144,12 @@ export async function getCertsWithManifest(platform_manifest, pceid) {
+     },
+     method: 'POST',
+     headers: {
+-      'Ocp-Apim-Subscription-Key': Config.get('ApiKey'),
+       'Content-Type': 'application/json',
+     },
+   };
+ 
++  const apikey = Config.get('ApiKey'); if (apikey) options.headers['Ocp-Apim-Subscription-Key'] = apikey;
++
+   return do_request(Config.get('uri') + 'pckcerts', options);
+ }
+ 

--- a/pccs/setup.sh
+++ b/pccs/setup.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -e
+
+# generate certificate and private key
+mkdir -p ./ssl_key
+cd ./ssl_key
+openssl genrsa -out private.pem 2048
+openssl req -new -key private.pem -out csr.pem -subj '/CN=localhost'
+openssl x509 -req -days 365 -in csr.pem -signkey private.pem -out file.crt
+rm -rf csr.pem && chmod 644 ./*
+
+
+# set values in config
+cd ../config/
+if [ -n "$APIKEY" ]; then
+    apikey="$APIKEY"
+    sed -i "s/\"ApiKey\"[ ]*:[ ]*\"\",/\"ApiKey\": \"$apikey\",/" default.json
+else
+    echo "ERROR: You need to submit an APIKEY, otherwise your PCCS can not connect to the PCS"
+    exit 1
+fi
+
+if [ -n "$USERPASS" ]; then
+    userpass="$USERPASS"
+else
+    userpass=$(openssl rand -hex 64)
+fi
+userhash=$(echo -n "$userpass" | sha512sum | tr -d '[:space:]-')
+sed -i "s/\"UserTokenHash\"[ ]*:[ ]*\"\",/\"UserTokenHash\": \"$userhash\",/" default.json
+
+if [ -n "$ADMINPASS" ]; then
+    adminpass="$ADMINPASS"
+else
+    adminpass=$(openssl rand -hex 64)
+fi
+adminhash=$(echo -n "$adminpass" | sha512sum | tr -d '[:space:]-')
+sed -i "s/\"AdminTokenHash\"[ ]*:[ ]*\"\",/\"AdminTokenHash\": \"$adminhash\",/" default.json
+
+sed -i 's/\"hosts\"[ ]*:[ ]*\"127.0.0.1\",/\"hosts\": \"0.0.0.0\",/' default.json
+
+cd ..
+/usr/bin/node /opt/intel/pccs/pccs_server.js

--- a/pccs/setup.sh
+++ b/pccs/setup.sh
@@ -16,9 +16,6 @@ cd ../config/
 if [ -n "$APIKEY" ]; then
     apikey="$APIKEY"
     sed -i "s/\"ApiKey\"[ ]*:[ ]*\"\",/\"ApiKey\": \"$apikey\",/" default.json
-else
-    echo "ERROR: You need to submit an APIKEY, otherwise your PCCS can not connect to the PCS"
-    exit 1
 fi
 
 if [ -n "$USERPASS" ]; then


### PR DESCRIPTION
PCS doesn't require an API key anymore. To be precise, you can use it either without providing the header field or with providing a valid API key, but not with providing an empty or invalid header field. We need to apply a patch to make the reference implementation omit the header field if no API key is configured.

### Proposed changes
- Move pccs source from era to ego (I'll archive era afterward)
- Update pccs to last available version
- Make API key optional

First commit adds existing files to this repo. Second commit makes the changes, so that commit is the interesting one to review.